### PR TITLE
Removes floating doubles of widgets and panels.

### DIFF
--- a/openhantek/src/openhantek.cpp
+++ b/openhantek/src/openhantek.cpp
@@ -498,10 +498,10 @@ void OpenHantekMainWindow::applySettings() {
 	
 	for(int dockId = 0; dockId < docks.size(); ++dockId) {
 		docks[dockId]->setVisible(dockSettings[dockId]->visible);
+		docks[dockId]->setFloating(dockSettings[dockId]->floating);
 		if(!dockSettings[dockId]->position.isNull()) {
 			if(dockSettings[dockId]->floating) {
 				this->addDockWidget(Qt::RightDockWidgetArea, docks[dockId]);
-				docks[dockId]->setFloating(dockSettings[dockId]->floating);
 				docks[dockId]->move(dockSettings[dockId]->position);
 			}
 			else {
@@ -539,7 +539,7 @@ void OpenHantekMainWindow::applySettings() {
 	
 	for(int toolbarId = 0; toolbarId < toolbars.size(); ++toolbarId) {
 		toolbars[toolbarId]->setVisible(toolbarSettings[toolbarId]->visible);
-		//toolbars[toolbarId]->setFloating(toolbarSettings[toolbarId]->floating); // setFloating missing, a bug in Qt?
+		toolbars[toolbarId]->setWindowFlags(Qt::Tool);
 		if(!toolbarSettings[toolbarId]->position.isNull() && !toolbarSettings[toolbarId]->floating) {
 			/*if(toolbarSettings[toolbarId]->floating) {
 				toolbars[toolbarId]->move(toolbarSettings[toolbarId]->position);

--- a/openhantek/src/settings.cpp
+++ b/openhantek/src/settings.cpp
@@ -146,7 +146,7 @@ void DsoSettings::setChannelCount(unsigned int channels) {
 			newVoltage.name = QApplication::tr("CH%1").arg(channel + 1);
 			newVoltage.offset = 0.0;
 			newVoltage.trigger = 0.0;
-			newVoltage.used = (channel == 0);
+			newVoltage.used = false;
 			this->scope.voltage.insert(channel, newVoltage);
 		}
 		


### PR DESCRIPTION
When run on Ubuntu OpenHantek has some strange behaviour around the widgets, panels and labels on the scope view.[0]
At start up those parts of the UI will be in floating, undocked mode and sometimes simultaneously docked. Resizing the window will move the floating parts move with the edges of the window, but moving the window has no effect on them. 
I do not know if this is a bug in OpenHantek, in QT, or someplace else. I did however find that setting floating explicitly will make the issue go away.[1]

Note:
This patch also removes enabling CH1 by default as this seems to have some weird interaction at a point I have not been able to locate.
If 'used' is not set to false, the labels on the scope view will continue to float in separate windows.
Always setting it to false will actually remove all of the above behaviour (even for the panels).

I'd welcome feedback about what exactly is triggering this behaviour based on the value of 'used'.

[0] https://drive.google.com/file/d/0B0-qedZwVhB-a1o4bWFJYWZuakE/view
[1] https://drive.google.com/file/d/0B0-qedZwVhB-OFNpaHFaLW5lNnc/view