### PR TITLE
Fix installation instructions

### DIFF
--- a/openhantek-extractfw/INSTALL
+++ b/openhantek-extractfw/INSTALL
@@ -1,6 +1,7 @@
 To build dsoextractfw from source, you need bfd. Under Debian or Ubuntu you can just install the package libbfd-dev. I don't know the package names for other distributions but they may be similar.
 
 After you've installed the requirements run the following commands inside the directory of this package:
+$ autoreconf -vi
 $ ./configure
 $ make
 


### PR DESCRIPTION
It's impossible for a newcomer to build extractfw basing on current instructions.