### PR TITLE
Fix build on master

### DIFF
--- a/openhantek/CMakeLists.txt
+++ b/openhantek/CMakeLists.txt
@@ -19,9 +19,6 @@ file(GLOB_RECURSE QRC "res/*.qrc")
 
 add_definitions(-DVERSION="${VERSION}")
 
-add_subdirectory(translations)
-add_subdirectory(res)
-
 # make executable
 add_executable(${PROJECT_NAME} ${SRC} ${HEADERS} ${QRC})
 target_link_libraries(${PROJECT_NAME} Qt5::Widgets Qt5::PrintSupport Qt5::OpenGL ${OPENGL_LIBRARIES} )

--- a/openhantek/src/helper.h
+++ b/openhantek/src/helper.h
@@ -77,7 +77,7 @@ namespace Helper {
 	/// \brief Print debug information with timestamp.
 	/// \param text Text that will be output via qDebug.
 	inline void timestampDebug(QString text) {
-		qDebug("%s: %s", QTime::currentTime().toString("hh:mm:ss.zzz").toAscii().constData(), text.toAscii().constData());
+		qDebug("%s: %s", QTime::currentTime().toString("hh:mm:ss.zzz").toLatin1().constData(), text.toLatin1().constData());
 	}
 #endif	
 	


### PR DESCRIPTION
Work in progress. It's still failing with:

```
openhantek/openhantek/src/main.cpp: In function ‘int main(int, char**)’:
openhantek/openhantek/src/main.cpp:45:70: error: ‘QMAKE_TRANSLATIONS_PATH’ was not declared in this scope
  openHantekTranslator.load("openhantek_" + QLocale::system().name(), QMAKE_TRANSLATIONS_PATH);
```

@davidgraeff any ideas?
