### PR TITLE
Fix travis build by removing unknown "file_glob" option

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -70,11 +70,8 @@ deploy:
   provider: releases
   api_key:
     secure: kIX221nPUe3OM5CNeEJ1iyRg2FFpmlL7c+uxJS11+HBRcFTGCIArHoxMIUb1u289+Co0jp42BVxhpo9PaKhHhzy3iVsKM1xOty3GAr9/1KzVnvJY0dOWqO2cYks4w24WF50ii3kUtYGVKpJrsHPT8UeI2z+taYr1jBmKkoYuoWDG+3CAZytLAsOVDRPylhzSD8B+OrCHIbN1npcitEpFUMJWgvDVi6ZKsz8o6obs/NhwFEc9TBDhS7CeIoAcNt7S0WdDM4ZyHyOeYShWxL0DlZBuhvS7SVZbxy/DS/cTAyoaWqgFLQokmhsKkVIytnq40kC9kGUZvoSpfwtfnA55eElFP5sNbnjQEUaDgq8Doi+aTTc7WRmhBCJbmz6RlqPAECQzx67JuTukV7F6Ds6B34+9naV3dAhj7dnMAoIvY1UK4NhvT+w3aQNR3B93TLZfYHvAmVoZcMGEY/EqLbHdMdJ7E9YGEQQUXW/753EmulCu9/O/gEs+8DlNc1ejFUGJhQmTyJBOLupJpFanC+6mTcbSGlJLwAHxL5yuJ0x5xLzZvJ9jTJI1QFu8ZztFw6gPCBpxPVle6E/Ht3CIByoK5RtKzhJBxgYDG+k0Yaqgbp1wh1ET56xEj8GxQlTKW43Mwbt4aXAarZ11C3erab5lCQyubIUXuq0TWxJLDTfOC6I=
-  file_glob: true
   file: "packages/OpenHantekProject-*"
   on:
     repo: OpenHantek/openhantek
-    branch: master
     condition: "$CMAKE_CXX_COMPILER = clang++-3.6"
     tags: true
-	


### PR DESCRIPTION
This was introduced in 5074707. Since then travis fails to build; it
says "missing config".[1]

Unfortunately the travis validation at http://lint.travis-ci.org/
is out of date; it doesn't even know about the "file" option, nor
"addons", "notifications", etc.
So I tested this by trial and error.

According to the comment on this stackoverflow answer[2] the "file_glob"
option existed at some point but now has been removed, and it is
implied.

I've also removed "branch: master" to avoid confusion, because "tags:
true" (added in 5074707) causes the "branch" condition to be
ignored.[3]

[1]: https://travis-ci.org/OpenHantek/openhantek/requests
[2]: http://stackoverflow.com/a/28579635/606705
[3]: https://docs.travis-ci.com/user/deployment/#Conditional-Releases-with-on%3A