### PR TITLE
Update readme.rd info for OSX in cmake

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -36,6 +36,11 @@ After you've installed the requirements either run **cmake-gui** or run the foll
 > make -j4 (for 4 concurrent compile jobs) <br>
 > make install (optional, for installing only)
 
+For MacOSX, the cmake command in the previous command list must include the directory where Qt5 is installed. Qt5 is installed in a directory with the same name of its version:
+> brew info qt5
+For example, if brew showed 5.7.0, the cmake command should be:
+> cmake ../ -DCMAKE_PREFIX_PATH=/usr/local/Cellar/qt5/5.7.0
+
 You can specify an install prefix when running cmake:
 > cmake -DCMAKE_INSTALL_PREFIX=/usr
 


### PR DESCRIPTION
cmake gave the following error when using the instructions given in the readme:

CMake Error at openhantek/CMakeLists.txt:3 (find_package):
  By not providing "FindQt5Widgets.cmake" in CMAKE_MODULE_PATH this project
  has asked CMake to find a package configuration file provided by
  "Qt5Widgets", but CMake did not find one.

  Could not find a package configuration file provided by "Qt5Widgets" with
  any of the following names:

    Qt5WidgetsConfig.cmake
    qt5widgets-config.cmake

  Add the installation prefix of "Qt5Widgets" to CMAKE_PREFIX_PATH or set
  "Qt5Widgets_DIR" to a directory containing one of the above files.  If
  "Qt5Widgets" provides a separate development package or SDK, be sure it has
  been installed.


-- Configuring incomplete, errors occurred!

This happens because cmake does not have information about where is Qt5 located. I added the instructions needed to achieve this with no problems.