### PR TITLE
Color config dialog change + minor bugfixes

### DIFF
--- a/openhantek/src/configdialog.cpp
+++ b/openhantek/src/configdialog.cpp
@@ -56,6 +56,7 @@ DsoConfigDialog::DsoConfigDialog(DsoSettings *settings, QWidget *parent,
       QSize(CONFIG_LIST_WIDTH - 2 * this->contentsWidget->frameWidth(),
             CONFIG_LIST_ITEMHEIGHT));
   this->contentsWidget->setMaximumWidth(CONFIG_LIST_WIDTH);
+  this->contentsWidget->setMinimumWidth(CONFIG_LIST_WIDTH);
   this->contentsWidget->setMinimumHeight(
       CONFIG_LIST_ITEMHEIGHT * 3 + 2 * (this->contentsWidget->frameWidth()));
 

--- a/openhantek/src/configpages.cpp
+++ b/openhantek/src/configpages.cpp
@@ -125,115 +125,161 @@ DsoConfigColorsPage::DsoConfigColorsPage(DsoSettings *settings, QWidget *parent)
   this->settings = settings;
 
   // Initialize elements
-  // Screen category
+  DsoSettingsViewColor& colorSettings = this->settings->view.color;
+  enum {
+    COL_LABEL = 0,
+    COL_SCR_CHANNEL,
+    COL_SCR_SPECTRUM,
+    COL_PRT_CHANNEL,
+    COL_PRT_SPECTRUM
+  };
+
+  // Plot Area
+  this->graphLabel = new QLabel(tr("<hr width=\"100%\"/>")); // 4*80
+  this->graphLabel->setAlignment(Qt::AlignRight);
+  this->graphLabel->setTextFormat(Qt::RichText);
+
+  this->screenColorsLabel = new QLabel(tr("Screen"));
+  this->screenColorsLabel->setAlignment(Qt::AlignHCenter);
+  this->printColorsLabel = new QLabel(tr("Print"));
+  this->printColorsLabel->setAlignment(Qt::AlignHCenter);
+
   this->axesLabel = new QLabel(tr("Axes"));
-  this->axesColorBox = new ColorBox(this->settings->view.color.screen.axes);
+  this->axesColorBox = new ColorBox(colorSettings.screen.axes);
+  this->printAxesColorBox = new ColorBox(colorSettings.print.axes);
+
   this->backgroundLabel = new QLabel(tr("Background"));
-  this->backgroundColorBox =
-      new ColorBox(this->settings->view.color.screen.background);
-  this->borderLabel = new QLabel(tr("Border"));
-  this->borderColorBox = new ColorBox(this->settings->view.color.screen.border);
-  this->gridLabel = new QLabel(tr("Grid"));
-  this->gridColorBox = new ColorBox(this->settings->view.color.screen.grid);
-  this->markersLabel = new QLabel(tr("Markers"));
-  this->markersColorBox =
-      new ColorBox(this->settings->view.color.screen.markers);
-  this->textLabel = new QLabel(tr("Text"));
-  this->textColorBox = new ColorBox(this->settings->view.color.screen.text);
-
-  this->screenLayout = new QGridLayout();
-  this->screenLayout->setColumnStretch(0, 1);
-  this->screenLayout->setColumnMinimumWidth(1, 80);
-  this->screenLayout->addWidget(this->backgroundLabel, 0, 0);
-  this->screenLayout->addWidget(this->backgroundColorBox, 0, 1);
-  this->screenLayout->addWidget(this->gridLabel, 1, 0);
-  this->screenLayout->addWidget(this->gridColorBox, 1, 1);
-  this->screenLayout->addWidget(this->axesLabel, 2, 0);
-  this->screenLayout->addWidget(this->axesColorBox, 2, 1);
-  this->screenLayout->addWidget(this->borderLabel, 3, 0);
-  this->screenLayout->addWidget(this->borderColorBox, 3, 1);
-  this->screenLayout->addWidget(this->markersLabel, 4, 0);
-  this->screenLayout->addWidget(this->markersColorBox, 4, 1);
-  this->screenLayout->addWidget(this->textLabel, 5, 0);
-  this->screenLayout->addWidget(this->textColorBox, 5, 1);
-
-  this->screenGroup = new QGroupBox(tr("Screen"));
-  this->screenGroup->setLayout(this->screenLayout);
-
-  // Print category
-  this->printAxesLabel = new QLabel(tr("Axes"));
-  this->printAxesColorBox = new ColorBox(this->settings->view.color.print.axes);
-  this->printBackgroundLabel = new QLabel(tr("Background"));
+  this->backgroundColorBox = new ColorBox(colorSettings.screen.background);
   this->printBackgroundColorBox =
-      new ColorBox(this->settings->view.color.print.background);
-  this->printBorderLabel = new QLabel(tr("Border"));
-  this->printBorderColorBox =
-      new ColorBox(this->settings->view.color.print.border);
-  this->printGridLabel = new QLabel(tr("Grid"));
-  this->printGridColorBox = new ColorBox(this->settings->view.color.print.grid);
-  this->printMarkersLabel = new QLabel(tr("Markers"));
+      new ColorBox(colorSettings.print.background);
+
+  this->borderLabel = new QLabel(tr("Border"));
+  this->borderColorBox = new ColorBox(colorSettings.screen.border);
+  this->printBorderColorBox = new ColorBox(colorSettings.print.border);
+
+  this->gridLabel = new QLabel(tr("Grid"));
+  this->gridColorBox = new ColorBox(colorSettings.screen.grid);
+  this->printGridColorBox = new ColorBox(colorSettings.print.grid);
+
+  this->markersLabel = new QLabel(tr("Markers"));
+  this->markersColorBox = new ColorBox(colorSettings.screen.markers);
   this->printMarkersColorBox =
-      new ColorBox(this->settings->view.color.print.markers);
-  this->printTextLabel = new QLabel(tr("Text"));
-  this->printTextColorBox = new ColorBox(this->settings->view.color.print.text);
+      new ColorBox(colorSettings.print.markers);
 
-  this->printLayout = new QGridLayout();
-  this->printLayout->setColumnStretch(0, 1);
-  this->printLayout->setColumnMinimumWidth(1, 80);
-  this->printLayout->addWidget(this->printBackgroundLabel, 0, 0);
-  this->printLayout->addWidget(this->printBackgroundColorBox, 0, 1);
-  this->printLayout->addWidget(this->printGridLabel, 1, 0);
-  this->printLayout->addWidget(this->printGridColorBox, 1, 1);
-  this->printLayout->addWidget(this->printAxesLabel, 2, 0);
-  this->printLayout->addWidget(this->printAxesColorBox, 2, 1);
-  this->printLayout->addWidget(this->printBorderLabel, 3, 0);
-  this->printLayout->addWidget(this->printBorderColorBox, 3, 1);
-  this->printLayout->addWidget(this->printMarkersLabel, 4, 0);
-  this->printLayout->addWidget(this->printMarkersColorBox, 4, 1);
-  this->printLayout->addWidget(this->printTextLabel, 5, 0);
-  this->printLayout->addWidget(this->printTextColorBox, 5, 1);
-
-  this->printGroup = new QGroupBox(tr("Print"));
-  this->printGroup->setLayout(this->printLayout);
+  this->textLabel = new QLabel(tr("Text"));
+  this->textColorBox = new ColorBox(colorSettings.screen.text);
+  this->printTextColorBox = new ColorBox(colorSettings.print.text);
 
   // Graph category
-  this->channelLabel = new QLabel(tr("Channel"));
-  this->channelLabel->setAlignment(Qt::AlignHCenter);
-  this->spectrumLabel = new QLabel(tr("Spectrum"));
-  this->spectrumLabel->setAlignment(Qt::AlignHCenter);
+  this->screenChannelLabel = new QLabel(tr("Channel"));
+  this->screenChannelLabel->setAlignment(Qt::AlignHCenter);
+  this->screenSpectrumLabel = new QLabel(tr("Spectrum"));
+  this->screenSpectrumLabel->setAlignment(Qt::AlignHCenter);
+  this->printChannelLabel = new QLabel(tr("Channel"));
+  this->printChannelLabel->setAlignment(Qt::AlignHCenter);
+  this->printSpectrumLabel = new QLabel(tr("Spectrum"));
+  this->printSpectrumLabel->setAlignment(Qt::AlignHCenter);
+
   for (int channel = 0; channel < this->settings->scope.voltage.count();
        ++channel) {
     this->colorLabel.append(
         new QLabel(this->settings->scope.voltage[channel].name));
-    this->channelColorBox.append(
-        new ColorBox(this->settings->view.color.screen.voltage[channel]));
-    this->spectrumColorBox.append(
-        new ColorBox(this->settings->view.color.screen.spectrum[channel]));
+    this->screenChannelColorBox.append(
+        new ColorBox(colorSettings.screen.voltage[channel]));
+    this->screenSpectrumColorBox.append(
+        new ColorBox(colorSettings.screen.spectrum[channel]));
+    this->printChannelColorBox.append(
+        new ColorBox(colorSettings.screen.voltage[channel]));
+    this->printSpectrumColorBox.append(
+        new ColorBox(colorSettings.screen.spectrum[channel]));
   }
 
-  this->graphLayout = new QGridLayout();
-  this->graphLayout->setColumnStretch(0, 1);
-  this->graphLayout->setColumnMinimumWidth(1, 80);
-  this->graphLayout->setColumnMinimumWidth(2, 80);
-  this->graphLayout->addWidget(this->channelLabel, 0, 1);
-  this->graphLayout->addWidget(this->spectrumLabel, 0, 2);
+  // Plot Area Layout
+  this->colorsLayout = new QGridLayout();
+  this->colorsLayout->setColumnStretch(COL_LABEL, 1);
+  this->colorsLayout->setColumnMinimumWidth(COL_SCR_CHANNEL, 80);
+  this->colorsLayout->setColumnMinimumWidth(COL_SCR_SPECTRUM, 80);
+  this->colorsLayout->setColumnMinimumWidth(COL_PRT_CHANNEL, 80);
+  this->colorsLayout->setColumnMinimumWidth(COL_PRT_SPECTRUM, 80);
+
+  int row = 0;
+  this->colorsLayout->addWidget(this->screenColorsLabel, row,
+                                COL_SCR_CHANNEL, 1, 2);
+  this->colorsLayout->addWidget(this->printColorsLabel, row,
+                                COL_PRT_CHANNEL, 1, 2);
+  ++row;
+  this->colorsLayout->addWidget(this->backgroundLabel, row, COL_LABEL);
+  this->colorsLayout->addWidget(this->backgroundColorBox,
+                                row, COL_SCR_CHANNEL, 1, 2);
+  this->colorsLayout->addWidget(this->printBackgroundColorBox,
+                                row, COL_PRT_CHANNEL, 1, 2);
+  ++row;
+  this->colorsLayout->addWidget(this->gridLabel, row, COL_LABEL);
+  this->colorsLayout->addWidget(this->gridColorBox,
+                                row, COL_SCR_CHANNEL, 1, 2);
+  this->colorsLayout->addWidget(this->printGridColorBox,
+                                row, COL_PRT_CHANNEL, 1, 2);
+  ++row;
+  this->colorsLayout->addWidget(this->axesLabel, row, COL_LABEL);
+  this->colorsLayout->addWidget(this->axesColorBox,
+                                row, COL_SCR_CHANNEL, 1, 2);
+  this->colorsLayout->addWidget(this->printAxesColorBox,
+                                row, COL_PRT_CHANNEL, 1, 2);
+  ++row;
+  this->colorsLayout->addWidget(this->borderLabel, row, COL_LABEL);
+  this->colorsLayout->addWidget(this->borderColorBox,
+                                row, COL_SCR_CHANNEL, 1, 2);
+  this->colorsLayout->addWidget(this->printBorderColorBox,
+                                row, COL_PRT_CHANNEL, 1, 2);
+  ++row;
+  this->colorsLayout->addWidget(this->markersLabel, row, COL_LABEL);
+  this->colorsLayout->addWidget(this->markersColorBox,
+                                row, COL_SCR_CHANNEL, 1, 2);
+  this->colorsLayout->addWidget(this->printMarkersColorBox,
+                                row, COL_PRT_CHANNEL, 1, 2);
+  ++row;
+  this->colorsLayout->addWidget(this->textLabel, row, COL_LABEL);
+  this->colorsLayout->addWidget(this->textColorBox,
+                                row, COL_SCR_CHANNEL, 1, 2);
+  this->colorsLayout->addWidget(this->printTextColorBox,
+                                row, COL_PRT_CHANNEL, 1, 2);
+  ++row;
+
+  // Graph
+  this->colorsLayout->addWidget(this->graphLabel, row, COL_LABEL, 1,
+                                COL_PRT_SPECTRUM - COL_LABEL + 1);
+  ++row;
+
+  this->colorsLayout->addWidget(this->screenChannelLabel, row,
+                                COL_SCR_CHANNEL);
+  this->colorsLayout->addWidget(this->screenSpectrumLabel, row,
+                                COL_SCR_SPECTRUM);
+  this->colorsLayout->addWidget(this->printChannelLabel, row,
+                                COL_PRT_CHANNEL);
+  this->colorsLayout->addWidget(this->printSpectrumLabel, row,
+                                COL_PRT_SPECTRUM);
+  ++row;
+
   for (int channel = 0; channel < this->settings->scope.voltage.count();
-       ++channel) {
-    this->graphLayout->addWidget(this->colorLabel[channel], channel + 1, 0);
-    this->graphLayout->addWidget(this->channelColorBox[channel], channel + 1,
-                                 1);
-    this->graphLayout->addWidget(this->spectrumColorBox[channel], channel + 1,
-                                 2);
+       ++channel, ++row) {
+    this->colorsLayout->addWidget(this->colorLabel[channel],
+                                  row, COL_LABEL);
+    this->colorsLayout->addWidget(this->screenChannelColorBox[channel],
+                                  row, COL_SCR_CHANNEL);
+    this->colorsLayout->addWidget(this->screenSpectrumColorBox[channel],
+                                  row, COL_SCR_SPECTRUM);
+    this->colorsLayout->addWidget(this->printChannelColorBox[channel],
+                                  row, COL_PRT_CHANNEL);
+    this->colorsLayout->addWidget(this->printSpectrumColorBox[channel],
+                                  row, COL_PRT_SPECTRUM);
   }
 
-  this->graphGroup = new QGroupBox(tr("Graph"));
-  this->graphGroup->setLayout(this->graphLayout);
+  this->colorsGroup = new QGroupBox(tr("Screen and Print Colors"));
+  this->colorsGroup->setLayout(this->colorsLayout);
 
   // Main layout
   this->mainLayout = new QVBoxLayout();
-  this->mainLayout->addWidget(this->screenGroup);
-  this->mainLayout->addWidget(this->printGroup);
-  this->mainLayout->addWidget(this->graphGroup);
+  this->mainLayout->addWidget(this->colorsGroup);
   this->mainLayout->addStretch(1);
 
   this->setLayout(this->mainLayout);
@@ -244,33 +290,36 @@ DsoConfigColorsPage::~DsoConfigColorsPage() {}
 
 /// \brief Saves the new settings.
 void DsoConfigColorsPage::saveSettings() {
+
+  DsoSettingsViewColor& colorSettings = this->settings->view.color;
+
   // Screen category
-  this->settings->view.color.screen.axes = this->axesColorBox->getColor();
-  this->settings->view.color.screen.background =
-      this->backgroundColorBox->getColor();
-  this->settings->view.color.screen.border = this->borderColorBox->getColor();
-  this->settings->view.color.screen.grid = this->gridColorBox->getColor();
-  this->settings->view.color.screen.markers = this->markersColorBox->getColor();
-  this->settings->view.color.screen.text = this->textColorBox->getColor();
+  colorSettings.screen.axes = this->axesColorBox->getColor();
+  colorSettings.screen.background = this->backgroundColorBox->getColor();
+  colorSettings.screen.border = this->borderColorBox->getColor();
+  colorSettings.screen.grid = this->gridColorBox->getColor();
+  colorSettings.screen.markers = this->markersColorBox->getColor();
+  colorSettings.screen.text = this->textColorBox->getColor();
 
   // Print category
-  this->settings->view.color.print.axes = this->printAxesColorBox->getColor();
-  this->settings->view.color.print.background =
-      this->printBackgroundColorBox->getColor();
-  this->settings->view.color.print.border =
-      this->printBorderColorBox->getColor();
-  this->settings->view.color.print.grid = this->printGridColorBox->getColor();
-  this->settings->view.color.print.markers =
-      this->printMarkersColorBox->getColor();
-  this->settings->view.color.print.text = this->printTextColorBox->getColor();
+  colorSettings.print.axes = this->printAxesColorBox->getColor();
+  colorSettings.print.background = this->printBackgroundColorBox->getColor();
+  colorSettings.print.border = this->printBorderColorBox->getColor();
+  colorSettings.print.grid = this->printGridColorBox->getColor();
+  colorSettings.print.markers = this->printMarkersColorBox->getColor();
+  colorSettings.print.text = this->printTextColorBox->getColor();
 
   // Graph category
   for (int channel = 0; channel < this->settings->scope.voltage.count();
        ++channel) {
-    this->settings->view.color.screen.voltage[channel] =
-        this->channelColorBox[channel]->getColor();
-    this->settings->view.color.screen.spectrum[channel] =
-        this->spectrumColorBox[channel]->getColor();
+    colorSettings.screen.voltage[channel] =
+        this->screenChannelColorBox[channel]->getColor();
+    colorSettings.screen.spectrum[channel] =
+        this->screenSpectrumColorBox[channel]->getColor();
+    colorSettings.print.voltage[channel] =
+        this->printChannelColorBox[channel]->getColor();
+    colorSettings.print.spectrum[channel] =
+        this->printSpectrumColorBox[channel]->getColor();
   }
 }
 
@@ -284,16 +333,10 @@ DsoConfigFilesPage::DsoConfigFilesPage(DsoSettings *settings, QWidget *parent)
   this->settings = settings;
 
   // Initialize elements
-  this->saveOnExitCheckBox = new QCheckBox(tr("Save default settings on exit"));
-  this->saveOnExitCheckBox->setChecked(this->settings->options.alwaysSave);
-  this->saveNowButton = new QPushButton(tr("Save default settings now"));
 
-  this->configurationLayout = new QVBoxLayout();
-  this->configurationLayout->addWidget(this->saveOnExitCheckBox, 0);
-  this->configurationLayout->addWidget(this->saveNowButton, 1);
-
-  this->configurationGroup = new QGroupBox(tr("Configuration"));
-  this->configurationGroup->setLayout(this->configurationLayout);
+  // Export group
+  this->screenColorCheckBox = new QCheckBox(tr("Export Images with Screen Colors"));
+  this->screenColorCheckBox->setChecked(this->settings->view.screenColorImages);
 
   this->imageWidthLabel = new QLabel(tr("Image width"));
   this->imageWidthSpinBox = new QSpinBox();
@@ -308,17 +351,31 @@ DsoConfigFilesPage::DsoConfigFilesPage(DsoSettings *settings, QWidget *parent)
       this->settings->options.imageSize.height());
 
   this->exportLayout = new QGridLayout();
-  this->exportLayout->addWidget(this->imageWidthLabel, 0, 0);
-  this->exportLayout->addWidget(this->imageWidthSpinBox, 0, 1);
-  this->exportLayout->addWidget(this->imageHeightLabel, 1, 0);
-  this->exportLayout->addWidget(this->imageHeightSpinBox, 1, 1);
+  this->exportLayout->addWidget(this->screenColorCheckBox, 0, 0, 1, 2);
+  this->exportLayout->addWidget(this->imageWidthLabel, 1, 0);
+  this->exportLayout->addWidget(this->imageWidthSpinBox, 1, 1);
+  this->exportLayout->addWidget(this->imageHeightLabel, 2, 0);
+  this->exportLayout->addWidget(this->imageHeightSpinBox, 2, 1);
 
   this->exportGroup = new QGroupBox(tr("Export"));
   this->exportGroup->setLayout(this->exportLayout);
 
+  // Configuration group
+  this->saveOnExitCheckBox = new QCheckBox(tr("Save default settings on exit"));
+  this->saveOnExitCheckBox->setChecked(this->settings->options.alwaysSave);
+  this->saveNowButton = new QPushButton(tr("Save default settings now"));
+
+  this->configurationLayout = new QVBoxLayout();
+  this->configurationLayout->addWidget(this->saveOnExitCheckBox, 0);
+  this->configurationLayout->addWidget(this->saveNowButton, 1);
+
+  this->configurationGroup = new QGroupBox(tr("Configuration"));
+  this->configurationGroup->setLayout(this->configurationLayout);
+
+  // Main layout
   this->mainLayout = new QVBoxLayout();
-  this->mainLayout->addWidget(this->configurationGroup);
   this->mainLayout->addWidget(this->exportGroup);
+  this->mainLayout->addWidget(this->configurationGroup);
   this->mainLayout->addStretch(1);
 
   this->setLayout(this->mainLayout);
@@ -332,6 +389,7 @@ DsoConfigFilesPage::~DsoConfigFilesPage() {}
 /// \brief Saves the new settings.
 void DsoConfigFilesPage::saveSettings() {
   this->settings->options.alwaysSave = this->saveOnExitCheckBox->isChecked();
+  this->settings->view.screenColorImages = this->screenColorCheckBox->isChecked();
   this->settings->options.imageSize.setWidth(this->imageWidthSpinBox->value());
   this->settings->options.imageSize.setHeight(
       this->imageHeightSpinBox->value());

--- a/openhantek/src/configpages.cpp
+++ b/openhantek/src/configpages.cpp
@@ -189,9 +189,9 @@ DsoConfigColorsPage::DsoConfigColorsPage(DsoSettings *settings, QWidget *parent)
     this->screenSpectrumColorBox.append(
         new ColorBox(colorSettings.screen.spectrum[channel]));
     this->printChannelColorBox.append(
-        new ColorBox(colorSettings.screen.voltage[channel]));
+        new ColorBox(colorSettings.print.voltage[channel]));
     this->printSpectrumColorBox.append(
-        new ColorBox(colorSettings.screen.spectrum[channel]));
+        new ColorBox(colorSettings.print.spectrum[channel]));
   }
 
   // Plot Area Layout

--- a/openhantek/src/configpages.h
+++ b/openhantek/src/configpages.h
@@ -92,26 +92,27 @@ private:
 
   QVBoxLayout *mainLayout;
 
-  QGroupBox *screenGroup;
-  QGridLayout *screenLayout;
+  QGroupBox *colorsGroup;
+  QGridLayout *colorsLayout;
+
+  QLabel *screenColorsLabel, *printColorsLabel;
   QLabel *axesLabel, *backgroundLabel, *borderLabel, *gridLabel, *markersLabel,
       *textLabel;
   ColorBox *axesColorBox, *backgroundColorBox, *borderColorBox, *gridColorBox,
       *markersColorBox, *textColorBox;
 
-  QGroupBox *printGroup;
-  QGridLayout *printLayout;
-  QLabel *printAxesLabel, *printBackgroundLabel, *printBorderLabel,
-      *printGridLabel, *printMarkersLabel, *printTextLabel;
   ColorBox *printAxesColorBox, *printBackgroundColorBox, *printBorderColorBox,
       *printGridColorBox, *printMarkersColorBox, *printTextColorBox;
 
-  QGroupBox *graphGroup;
-  QGridLayout *graphLayout;
-  QLabel *channelLabel, *spectrumLabel;
+  QLabel *graphLabel;
+
+  QLabel *screenChannelLabel, *screenSpectrumLabel, *printChannelLabel,
+      *printSpectrumLabel;
   QList<QLabel *> colorLabel;
-  QList<ColorBox *> channelColorBox;
-  QList<ColorBox *> spectrumColorBox;
+  QList<ColorBox *> screenChannelColorBox;
+  QList<ColorBox *> screenSpectrumColorBox;
+  QList<ColorBox *> printChannelColorBox;
+  QList<ColorBox *> printSpectrumColorBox;
 
 private slots:
 };
@@ -141,6 +142,7 @@ private:
 
   QGroupBox *exportGroup;
   QGridLayout *exportLayout;
+  QCheckBox *screenColorCheckBox;
   QLabel *imageWidthLabel;
   QSpinBox *imageWidthSpinBox;
   QLabel *imageHeightLabel;

--- a/openhantek/src/exporter.cpp
+++ b/openhantek/src/exporter.cpp
@@ -206,14 +206,16 @@ bool Exporter::doExport() {
                 tr("/div"),
             QTextOption(Qt::AlignRight));
         // Print spectrum magnitude
-        painter.setPen(colorValues->spectrum[channel]);
-        painter.drawText(QRectF(lineHeight * 6 + stretchBase * 2, top,
-                                stretchBase * 2, lineHeight),
-                         Helper::valueToString(
-                             this->settings->scope.spectrum[channel].magnitude,
-                             Helper::UNIT_DECIBEL, 0) +
-                             tr("/div"),
-                         QTextOption(Qt::AlignRight));
+        if (this->settings->scope.spectrum[channel].used) {
+            painter.setPen(colorValues->spectrum[channel]);
+            painter.drawText(QRectF(lineHeight * 6 + stretchBase * 2, top,
+                                    stretchBase * 2, lineHeight),
+                             Helper::valueToString(
+                                 this->settings->scope.spectrum[channel].magnitude,
+                                 Helper::UNIT_DECIBEL, 0) +
+                                 tr("/div"),
+                             QTextOption(Qt::AlignRight));
+        }
 
         // Amplitude string representation (4 significant digits)
         painter.setPen(colorValues->text);

--- a/openhantek/src/hantek/control.cpp
+++ b/openhantek/src/hantek/control.cpp
@@ -721,7 +721,7 @@ unsigned int Control::updateSamplerate(unsigned int downsampler,
       else { // Downsampling factors 3 and 4 are not supported
         samplerateId = 3;
         downsampler = 5;
-        downsamplerValue = 0xffff;
+        downsamplerValue = (short int)0xffff;
       }
     } else {
       // For any dividers above the downsampling factor can be set directly

--- a/openhantek/src/helper.h
+++ b/openhantek/src/helper.h
@@ -108,6 +108,7 @@ template <class T> T DataArray<T>::operator[](unsigned int index) {
 template <class T> unsigned int DataArray<T>::getSize() const {
   return this->size;
 }
-};
+
+} // namespace Helper
 
 #endif

--- a/openhantek/src/settings.cpp
+++ b/openhantek/src/settings.cpp
@@ -413,8 +413,7 @@ int DsoSettings::load(const QString &fileName) {
         (Dso::InterpolationMode)settingsLoader->value("interpolation").toInt();
   if (settingsLoader->contains("screenColorImages"))
     this->view.screenColorImages =
-        (Dso::InterpolationMode)settingsLoader->value("screenColorImages")
-            .toBool();
+        settingsLoader->value("screenColorImages").toBool();
   if (settingsLoader->contains("zoom"))
     this->view.zoom =
         (Dso::InterpolationMode)settingsLoader->value("zoom").toBool();


### PR DESCRIPTION
1) Enable user to choose screen & print colors separately (option already supported by **DsoSettingsView.color**). 

2) Enabled "Export Images with Screen Colors" checkbox in "Files" dialog.

3) Couple of minor enhancements: fixed width of icons panel in Settings, suppress printing spectrum magnitude if spectrum is not printed.

4) Bugfixes:
Eliminated compile time warnings:

```
...helper.h:111:2: warning: extra ‘;’ [-Wpedantic]
 };
  ^
...control.cpp: In member function ‘unsigned int Hantek::Control::updateSamplerate(unsigned int, bool)’:
...control.cpp:724:26: warning: overflow in implicit constant conversion [-Woverflow]
         downsamplerValue = 0xffff;
                          ^
```

![files_dialog_screenshot](https://cloud.githubusercontent.com/assets/11679699/25874497/850b575c-351b-11e7-8cb9-e767ac1f569a.png)

![new_color_dialog_screenshot](https://cloud.githubusercontent.com/assets/11679699/25874411/25861b6e-351b-11e7-8cc5-22e09da094ac.png)
