### PR TITLE
CSV export in columns, math channel iterator fix

### DIFF
--- a/openhantek/src/dataanalyzer.cpp
+++ b/openhantek/src/dataanalyzer.cpp
@@ -174,15 +174,17 @@ void DataAnalyzer::run() {
                       .voltage[this->settings->scope.physicalChannels]
                       .misc) {
           case Dso::MATHMODE_1ADD2:
-            *(resultIterator++) = *(ch1Iterator++) + *(ch2Iterator++);
+            *resultIterator = *ch1Iterator + *ch2Iterator;
             break;
           case Dso::MATHMODE_1SUB2:
-            *(resultIterator++) = *(ch1Iterator++) - *(ch2Iterator++);
+            *resultIterator = *ch1Iterator - *ch2Iterator;
             break;
           case Dso::MATHMODE_2SUB1:
-            *(resultIterator++) = *(ch2Iterator++) - *(ch1Iterator++);
+            *resultIterator = *ch2Iterator - *ch1Iterator;
             break;
           }
+          ++ch1Iterator;
+          ++ch2Iterator;
         }
       }
     } else {

--- a/openhantek/src/hantek/control.cpp
+++ b/openhantek/src/hantek/control.cpp
@@ -266,6 +266,8 @@ int Control::getCaptureState() {
 int Control::getSamples(bool process) {
   int errorCode;
 
+  const unsigned int DROP_DSO6022_SAMPLES = 0x410;
+
   if (this->device->getModel() != MODEL_DSO6022BE) {
     // Request data
     errorCode = this->device->bulkCommand(this->command[BULK_GETDATA], 1);
@@ -393,9 +395,9 @@ int Control::getSamples(bool process) {
     } else {
       // Normal mode, channels are using their separate buffers
       sampleCount = totalSampleCount / HANTEK_CHANNELS;
-      // if device is 6022BE, drop first 1000 samples
+      // if device is 6022BE, drop first DROP_DSO6022_SAMPLES samples
       if (this->device->getModel() == MODEL_DSO6022BE)
-        sampleCount -= 1000;
+        sampleCount -= DROP_DSO6022_SAMPLES;
       for (int channel = 0; channel < HANTEK_CHANNELS; ++channel) {
         if (this->settings.voltage[channel].used) {
           // Resize sample vector
@@ -438,8 +440,8 @@ int Control::getSamples(bool process) {
           } else {
             if (this->device->getModel() == MODEL_DSO6022BE) {
               bufferPosition += channel;
-              // if device is 6022BE, offset 1000 incrementally
-              bufferPosition += 1000 * 2;
+              // if device is 6022BE, offset DROP_DSO6022_SAMPLES incrementally
+              bufferPosition += DROP_DSO6022_SAMPLES * 2;
             } else
               bufferPosition += HANTEK_CHANNELS - 1 - channel;
 


### PR DESCRIPTION
1) CSV export into long lines looks pretty useless, e.g. they make LibreOffice Calc fail with message "The data could not be loaded completely because the maximum number of columns per sheet was exceeded". Changed CSV export to columns. X-axis (time/frequency) values are printed in each line, thus making import into plot tools easier.
2) Fixed bug in MATH channel (double-increment of iterator), changed postfix iterator increments to prefix increments.
3) Improved DSO6022BE Software trigger stability by increasing dropped sample count to 1040 (0x410). Most likely the same buffer truncation needs to be applied to 6022BL. Still have to dive into jhoenicke's firmware, fast sample rates might require different approach to data acquisition.