### PR TITLE
GUI Enhancements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 .so
 .*~
 build/
+CMakeLists.txt.user

--- a/openhantek/src/dockwindows.cpp
+++ b/openhantek/src/dockwindows.cpp
@@ -52,7 +52,7 @@ HorizontalDock::HorizontalDock(DsoSettings *settings, QWidget *parent,
   this->samplerateSiSpinBox->setUnitPostfix("/s");
 
   QList<double> timebaseSteps;
-  timebaseSteps << 1.0 << 2.0 << 4.0 << 10.0;
+  timebaseSteps << 1.0 << 2.0 << 5.0 << 10.0;
 
   this->timebaseLabel = new QLabel(tr("Timebase"));
   this->timebaseSiSpinBox = new SiSpinBox(Helper::UNIT_SECONDS);

--- a/openhantek/src/openhantek.cpp
+++ b/openhantek/src/openhantek.cpp
@@ -733,6 +733,7 @@ void OpenHantekMainWindow::samplerateSelected() {
 void OpenHantekMainWindow::timebaseSelected() {
   this->dsoControl->setRecordTime(this->settings->scope.horizontal.timebase *
                                   DIVS_TIME);
+  this->dsoWidget->updateTimebase(settings->scope.horizontal.timebase);
 }
 
 /// \brief Sets the offset of the oscilloscope for the given channel.


### PR DESCRIPTION
Is there any specific reason behind timebase steps 1-2-4-10?

1) Timebase steps 1-2-5-10 are more traditional, have better distribution on log scale
2) dsoWidget: enabled timebase update

3) Added CMakeLists.txt.user to .gitignore
