### PR TITLE
readme: add missing libqt5opengl5-dev

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -28,7 +28,7 @@ You need a OpenGL 3.x capable graphics card for OpenHantek.
 
 ### Install requirements on Linux
 For debian based systems (Ubuntu, Mint) install named requirements like this:
-> apt-get install g++ cmake qttools5-dev qttools5-dev-tools libfftw3-dev binutils-dev libusb-1.0-0-dev
+> apt install g++ cmake qttools5-dev qttools5-dev-tools libfftw3-dev binutils-dev libusb-1.0-0-dev libqt5opengl5-dev
 
 For rpm based distributions (Fedora) use this command:
 > dnf install cmake gcc-c++ qt5-qtbase-gui qt5-qttools-devel qt5-qttranslations fftw-devel binutils-devel libusb-devel


### PR DESCRIPTION
Without this package, I ran into the following error:

```
~/openhantek/build master $ cmake ..
-- The C compiler identification is GNU 7.2.0
-- The CXX compiler identification is GNU 7.2.0
-- Check for working C compiler: /usr/bin/cc
-- Check for working C compiler: /usr/bin/cc -- works
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Detecting C compile features
-- Detecting C compile features - done
-- Check for working CXX compiler: /usr/bin/c++
-- Check for working CXX compiler: /usr/bin/c++ -- works
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Detecting CXX compile features
ma-- Detecting CXX compile features - done
CMake Error at openhantek/CMakeLists.txt:5 (find_package):
  By not providing "FindQt5OpenGL.cmake" in CMAKE_MODULE_PATH this project
  has asked CMake to find a package configuration file provided by
  "Qt5OpenGL", but CMake did not find one.

  Could not find a package configuration file provided by "Qt5OpenGL" with
  any of the following names:

    Qt5OpenGLConfig.cmake
    qt5opengl-config.cmake

  Add the installation prefix of "Qt5OpenGL" to CMAKE_PREFIX_PATH or set
  "Qt5OpenGL_DIR" to a directory containing one of the above files.  If
  "Qt5OpenGL" provides a separate development package or SDK, be sure it has
  been installed.


-- Configuring incomplete, errors occurred!
See also "/home/michael/openhantek/build/CMakeFiles/CMakeOutput.log".
```