### PR TITLE
Improved 6022BE stability + timebase display fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,5 @@
 .o
 .so
 .*~
+CMakeLists.txt.user
 build/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,7 +18,7 @@ add_subdirectory(openhantek)
 include(cmake/CPackInfos.cmake)
 
 if (WIN32)
-    install(FILES ChangeLog COPYING readme.md DESTINATION ".")
+    install(FILES COPYING readme.md DESTINATION ".")
 endif()
 
 # Add auxiliary files to the project, so that these files appear in VisualStudio/QtCreator

--- a/openhantek/src/dockwindows.h
+++ b/openhantek/src/dockwindows.h
@@ -51,7 +51,7 @@ public:
 
   void setFrequencybase(double timebase);
   void setSamplerate(double samplerate);
-  void setTimebase(double timebase);
+  double setTimebase(double timebase);
   void setRecordLength(unsigned int recordLength);
   int setFormat(Dso::GraphFormat format);
 
@@ -75,6 +75,7 @@ protected:
                              ///interpreted and shown
 
   DsoSettings *settings; ///< The settings provided by the parent class
+  QList<double> timebaseSteps; ///< Steps for the timebase spinbox
 
   QStringList formatStrings; ///< Strings for the formats
 

--- a/openhantek/src/openhantek.cpp
+++ b/openhantek/src/openhantek.cpp
@@ -691,9 +691,8 @@ void OpenHantekMainWindow::recordTimeChanged(double duration) {
   if (this->settings->scope.horizontal.samplerateSet &&
       this->settings->scope.horizontal.recordLength != UINT_MAX) {
     // The samplerate was set, let's adapt the timebase accordingly
-    this->settings->scope.horizontal.timebase = duration / DIVS_TIME;
-    this->horizontalDock->setTimebase(
-        this->settings->scope.horizontal.timebase);
+    this->settings->scope.horizontal.timebase =
+      this->horizontalDock->setTimebase(duration / DIVS_TIME);
   }
 
   // The trigger position should be kept at the same place but the timebase has
@@ -733,6 +732,7 @@ void OpenHantekMainWindow::samplerateSelected() {
 void OpenHantekMainWindow::timebaseSelected() {
   this->dsoControl->setRecordTime(this->settings->scope.horizontal.timebase *
                                   DIVS_TIME);
+  this->dsoWidget->updateTimebase(settings->scope.horizontal.timebase);
 }
 
 /// \brief Sets the offset of the oscilloscope for the given channel.


### PR DESCRIPTION
1) Improved 6022BE SW trigger stability & waveform display by further reducing record length down to 8KS, drop 1K+16 samples from the head and 1K-16 from the tail.
2) Removed 32KS record length option for 6022BE (eventually all record lengths are converted into 10K by hack #59; however disabling 'Roll' option is not so easy)
```
    // For now - we go for the 10240 size sampling - the other seems not to be
    // supported
    // Find highest samplerate using less than 10240 samples to obtain our
    // duration.
    // Better add some margin for our SW trigger
```
3) Cherry-picked items 2 & 3 from #70 (closed).

Screenshots:
FIFO overflow and wrong timebase display
![before-highlight](https://user-images.githubusercontent.com/11679699/33338641-bda562f4-d487-11e7-85bd-e163dfe517c6.png)
Fix in place
![fixed-highlight](https://user-images.githubusercontent.com/11679699/33338670-d0c1c198-d487-11e7-9dc5-051d4c665738.png)

