### PR TITLE
Load / save states of docking windows and toolbars

### DIFF
--- a/openhantek/src/dockwindows.cpp
+++ b/openhantek/src/dockwindows.cpp
@@ -35,6 +35,19 @@
 #include "settings.h"
 #include "sispinbox.h"
 
+namespace {
+
+void SetupDockWidget(QDockWidget *dockWindow, QWidget *dockWidget, QLayout *layout) {
+  dockWindow->setObjectName(dockWindow->windowTitle());
+  dockWindow->setAllowedAreas(Qt::LeftDockWidgetArea | Qt::RightDockWidgetArea);
+  dockWidget->setLayout(layout);
+  dockWidget->setSizePolicy(QSizePolicy(QSizePolicy::Minimum, QSizePolicy::Fixed,
+                                   QSizePolicy::DefaultType));
+  dockWindow->setWidget(dockWidget);
+}
+
+}
+
 ////////////////////////////////////////////////////////////////////////////////
 // class HorizontalDock
 /// \brief Initializes the horizontal axis docking window.
@@ -90,11 +103,8 @@ HorizontalDock::HorizontalDock(DsoSettings *settings, QWidget *parent,
   this->dockLayout->addWidget(this->formatLabel, 4, 0);
   this->dockLayout->addWidget(this->formatComboBox, 4, 1);
 
-  this->setAllowedAreas(Qt::LeftDockWidgetArea | Qt::RightDockWidgetArea);
-
   this->dockWidget = new QWidget();
-  this->dockWidget->setLayout(this->dockLayout);
-  this->setWidget(this->dockWidget);
+  SetupDockWidget(this, dockWidget, dockLayout);
 
   // Connect signals and slots
   connect(this->samplerateSiSpinBox, SIGNAL(valueChanged(double)), this,
@@ -337,11 +347,8 @@ TriggerDock::TriggerDock(DsoSettings *settings,
   this->dockLayout->addWidget(this->slopeLabel, 2, 0);
   this->dockLayout->addWidget(this->slopeComboBox, 2, 1);
 
-  this->setAllowedAreas(Qt::LeftDockWidgetArea | Qt::RightDockWidgetArea);
-
   this->dockWidget = new QWidget();
-  this->dockWidget->setLayout(this->dockLayout);
-  this->setWidget(this->dockWidget);
+  SetupDockWidget(this, dockWidget, dockLayout);
 
   // Connect signals and slots
   connect(this->modeComboBox, SIGNAL(currentIndexChanged(int)), this,
@@ -479,11 +486,8 @@ SpectrumDock::SpectrumDock(DsoSettings *settings, QWidget *parent,
     this->dockLayout->addWidget(this->magnitudeComboBox[channel], channel, 1);
   }
 
-  this->setAllowedAreas(Qt::LeftDockWidgetArea | Qt::RightDockWidgetArea);
-
   this->dockWidget = new QWidget();
-  this->dockWidget->setLayout(this->dockLayout);
-  this->setWidget(this->dockWidget);
+  SetupDockWidget(this, dockWidget, dockLayout);
 
   // Connect signals and slots
   for (int channel = 0; channel < this->settings->scope.voltage.count();
@@ -630,11 +634,8 @@ VoltageDock::VoltageDock(DsoSettings *settings, QWidget *parent,
                                 1);
   }
 
-  this->setAllowedAreas(Qt::LeftDockWidgetArea | Qt::RightDockWidgetArea);
-
   this->dockWidget = new QWidget();
-  this->dockWidget->setLayout(this->dockLayout);
-  this->setWidget(this->dockWidget);
+  SetupDockWidget(this, dockWidget, dockLayout);
 
   // Connect signals and slots
   for (int channel = 0; channel < this->settings->scope.voltage.count();

--- a/openhantek/src/openhantek.h
+++ b/openhantek/src/openhantek.h
@@ -70,10 +70,6 @@ private:
   int readSettings(const QString &fileName = QString());
   int writeSettings(const QString &fileName = QString());
 
-  // Window translation events
-  void moveEvent(QMoveEvent *event);
-  void resizeEvent(QResizeEvent *event);
-
   // Actions
   QAction *newAction, *openAction, *saveAction, *saveAsAction;
   QAction *printAction, *exportAsAction;

--- a/openhantek/src/settings.cpp
+++ b/openhantek/src/settings.cpp
@@ -36,24 +36,6 @@ DsoSettings::DsoSettings(QWidget *parent) : QObject(parent) {
   // Options
   this->options.alwaysSave = true;
   this->options.imageSize = QSize(640, 480);
-  // Main window
-  this->options.window.position = QPoint();
-  this->options.window.size = QSize(800, 600);
-  // Docking windows and toolbars
-  QList<DsoSettingsOptionsWindowPanel *> panels;
-  panels.append(&(this->options.window.dock.horizontal));
-  panels.append(&(this->options.window.dock.spectrum));
-  panels.append(&(this->options.window.dock.trigger));
-  panels.append(&(this->options.window.dock.voltage));
-  panels.append(&(this->options.window.toolbar.file));
-  panels.append(&(this->options.window.toolbar.oscilloscope));
-  panels.append(&(this->options.window.toolbar.view));
-  for (int panelId = 0; panelId < panels.size(); ++panelId) {
-    panels[panelId]->floating = false;
-    panels[panelId]->position = QPoint();
-    panels[panelId]->visible = true;
-  }
-
   // Oscilloscope settings
   // Horizontal axis
   this->scope.horizontal.format = Dso::GRAPHFORMAT_TY;
@@ -213,68 +195,17 @@ int DsoSettings::load(const QString &fileName) {
   if (settingsLoader->status() != QSettings::NoError)
     return -settingsLoader->status();
 
-  // Main window layout and other general options
-  settingsLoader->beginGroup("options");
-  settingsLoader->beginGroup("window");
-  // Docking windows and toolbars
-  settingsLoader->beginGroup("docks");
-  QList<DsoSettingsOptionsWindowPanel *> docks;
-  docks.append(&(this->options.window.dock.horizontal));
-  docks.append(&(this->options.window.dock.spectrum));
-  docks.append(&(this->options.window.dock.trigger));
-  docks.append(&(this->options.window.dock.voltage));
-  QStringList dockNames;
-  dockNames << "horizontal"
-            << "spectrum"
-            << "trigger"
-            << "voltage";
-  for (int dockId = 0; dockId < docks.size(); ++dockId) {
-    settingsLoader->beginGroup(dockNames[dockId]);
-    if (settingsLoader->contains("floating"))
-      docks[dockId]->floating = settingsLoader->value("floating").toBool();
-    if (settingsLoader->contains("position"))
-      docks[dockId]->position = settingsLoader->value("position").toPoint();
-    if (settingsLoader->contains("visible"))
-      docks[dockId]->visible = settingsLoader->value("visible").toBool();
-    settingsLoader->endGroup();
-  }
-  settingsLoader->endGroup();
-  settingsLoader->beginGroup("toolbars");
-  QList<DsoSettingsOptionsWindowPanel *> toolbars;
-  toolbars.append(&(this->options.window.toolbar.file));
-  toolbars.append(&(this->options.window.toolbar.oscilloscope));
-  toolbars.append(&(this->options.window.toolbar.view));
-  QStringList toolbarNames;
-  toolbarNames << "file"
-               << "oscilloscope"
-               << "view";
-  for (int toolbarId = 0; toolbarId < toolbars.size(); ++toolbarId) {
-    settingsLoader->beginGroup(toolbarNames[toolbarId]);
-    if (settingsLoader->contains("floating"))
-      toolbars[toolbarId]->floating =
-          settingsLoader->value("floating").toBool();
-    if (settingsLoader->contains("position"))
-      toolbars[toolbarId]->position =
-          settingsLoader->value("position").toPoint();
-    if (settingsLoader->contains("visible"))
-      toolbars[toolbarId]->visible = settingsLoader->value("visible").toBool();
-    settingsLoader->endGroup();
-  }
-  settingsLoader->endGroup();
-  // Main window
-  if (settingsLoader->contains("pos"))
-    this->options.window.position = settingsLoader->value("pos").toPoint();
-  if (settingsLoader->contains("size"))
-    this->options.window.size = settingsLoader->value("size").toSize();
-  settingsLoader->endGroup();
   // General options
+  settingsLoader->beginGroup("options");
   if (settingsLoader->contains("alwaysSave"))
     this->options.alwaysSave = settingsLoader->value("alwaysSave").toBool();
   if (settingsLoader->contains("imageSize"))
     this->options.imageSize = settingsLoader->value("imageSize").toSize();
+  // If the window/* keys were found in this group, remove them from settings
+  settingsLoader->remove("window");
   settingsLoader->endGroup();
 
-  // Oszilloskope settings
+  // Oscilloscope settings
   settingsLoader->beginGroup("scope");
   // Horizontal axis
   settingsLoader->beginGroup("horizontal");
@@ -419,6 +350,11 @@ int DsoSettings::load(const QString &fileName) {
         (Dso::InterpolationMode)settingsLoader->value("zoom").toBool();
   settingsLoader->endGroup();
 
+  settingsLoader->beginGroup("window");
+  mainWindowGeometry = settingsLoader->value("geometry").toByteArray();
+  mainWindowState = settingsLoader->value("state").toByteArray();
+  settingsLoader->endGroup();
+
   delete settingsLoader;
 
   return 0;
@@ -441,48 +377,6 @@ int DsoSettings::save(const QString &fileName) {
   if (complete) {
     // Main window layout and other general options
     settingsSaver->beginGroup("options");
-    settingsSaver->beginGroup("window");
-    // Docking windows and toolbars
-    settingsSaver->beginGroup("docks");
-    QList<DsoSettingsOptionsWindowPanel *> docks;
-    docks.append(&(this->options.window.dock.horizontal));
-    docks.append(&(this->options.window.dock.spectrum));
-    docks.append(&(this->options.window.dock.trigger));
-    docks.append(&(this->options.window.dock.voltage));
-    QStringList dockNames;
-    dockNames << "horizontal"
-              << "spectrum"
-              << "trigger"
-              << "voltage";
-    for (int dockId = 0; dockId < docks.size(); ++dockId) {
-      settingsSaver->beginGroup(dockNames[dockId]);
-      settingsSaver->setValue("floating", docks[dockId]->floating);
-      settingsSaver->setValue("position", docks[dockId]->position);
-      settingsSaver->setValue("visible", docks[dockId]->visible);
-      settingsSaver->endGroup();
-    }
-    settingsSaver->endGroup();
-    settingsSaver->beginGroup("toolbars");
-    QList<DsoSettingsOptionsWindowPanel *> toolbars;
-    toolbars.append(&(this->options.window.toolbar.file));
-    toolbars.append(&(this->options.window.toolbar.oscilloscope));
-    toolbars.append(&(this->options.window.toolbar.view));
-    QStringList toolbarNames;
-    toolbarNames << "file"
-                 << "oscilloscope"
-                 << "view";
-    for (int toolbarId = 0; toolbarId < toolbars.size(); ++toolbarId) {
-      settingsSaver->beginGroup(toolbarNames[toolbarId]);
-      settingsSaver->setValue("floating", toolbars[toolbarId]->floating);
-      settingsSaver->setValue("position", toolbars[toolbarId]->position);
-      settingsSaver->setValue("visible", toolbars[toolbarId]->visible);
-      settingsSaver->endGroup();
-    }
-    settingsSaver->endGroup();
-    // Main window
-    settingsSaver->setValue("pos", this->options.window.position);
-    settingsSaver->setValue("size", this->options.window.size);
-    settingsSaver->endGroup();
     settingsSaver->setValue("alwaysSave", this->options.alwaysSave);
     settingsSaver->setValue("imageSize", this->options.imageSize);
     settingsSaver->endGroup();
@@ -574,6 +468,11 @@ int DsoSettings::save(const QString &fileName) {
     settingsSaver->setValue("screenColorImages", this->view.screenColorImages);
   }
   settingsSaver->setValue("zoom", this->view.zoom);
+  settingsSaver->endGroup();
+
+  settingsSaver->beginGroup("window");
+  settingsSaver->setValue("geometry", mainWindowGeometry);
+  settingsSaver->setValue("state", mainWindowState);
   settingsSaver->endGroup();
 
   delete settingsSaver;

--- a/openhantek/src/settings.h
+++ b/openhantek/src/settings.h
@@ -35,50 +35,11 @@
 #include "dso.h"
 
 ////////////////////////////////////////////////////////////////////////////////
-/// \struct DsoSettingsOptionsWindowPanel                             settings.h
-/// \brief Holds the position and state of a docking window or toolbar.
-struct DsoSettingsOptionsWindowPanel {
-  bool floating;   ///< true, if the panel is floating
-  QPoint position; ///< Position of the panel
-  bool visible;    ///< true, if the panel is shown
-};
-
-////////////////////////////////////////////////////////////////////////////////
-/// \struct DsoSettingsOptionsWindowDock                              settings.h
-/// \brief Holds the layout of the docking windows.
-struct DsoSettingsOptionsWindowDock {
-  DsoSettingsOptionsWindowPanel horizontal; ///< "Horizontal" docking window
-  DsoSettingsOptionsWindowPanel spectrum;   ///< "Spectrum" docking window
-  DsoSettingsOptionsWindowPanel trigger;    ///< "Trigger" docking window
-  DsoSettingsOptionsWindowPanel voltage;    ///< "Voltage" docking window
-};
-
-////////////////////////////////////////////////////////////////////////////////
-/// \struct DsoSettingsOptionsWindowToolbar                           settings.h
-/// \brief Holds the layout of the toolbars.
-struct DsoSettingsOptionsWindowToolbar {
-  DsoSettingsOptionsWindowPanel file;         ///< "File" toolbar
-  DsoSettingsOptionsWindowPanel oscilloscope; ///< "Oscilloscope" toolbar
-  DsoSettingsOptionsWindowPanel view;         ///< The "View" toolbar
-};
-
-////////////////////////////////////////////////////////////////////////////////
-/// \struct DsoSettingsOptionsWindow                                  settings.h
-/// \brief Holds the layout of the main window.
-struct DsoSettingsOptionsWindow {
-  QPoint position;                         ///< Position of the main window
-  QSize size;                              ///< Size of the main window
-  DsoSettingsOptionsWindowDock dock;       ///< Docking windows
-  DsoSettingsOptionsWindowToolbar toolbar; ///< Toolbars
-};
-
-////////////////////////////////////////////////////////////////////////////////
 /// \struct DsoSettingsOptions                                        settings.h
 /// \brief Holds the general options of the program.
 struct DsoSettingsOptions {
   bool alwaysSave;                 ///< Always save the settings on exit
   QSize imageSize;                 ///< Size of exported images in pixels
-  DsoSettingsOptionsWindow window; ///< Window layout
 };
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -194,6 +155,9 @@ public:
   DsoSettingsOptions options; ///< General options of the program
   DsoSettingsScope scope;     ///< All oscilloscope related settings
   DsoSettingsView view;       ///< All view related settings
+
+  QByteArray mainWindowGeometry; ///< Geometry of the main window
+  QByteArray mainWindowState;    ///< State of docking windows and toolbars
 
 public slots:
   // Saving to and loading from configuration files


### PR DESCRIPTION
The main window geometry and docking windows / toolbars layout are stored into new [window] section of .ini file. This PR addresses Issue #85.

Screenshot (1020x570)
![persistent_layout_annotated](https://user-images.githubusercontent.com/11679699/33526242-399c4f2e-d84f-11e7-842f-c1a75625ffc5.png)

Please also notice the vertical "File" toolbar on the left-hand side and floating toolbars above Voltage / Spectrum / Trigger tabs.
