### PR TITLE
Settings refactored. MainWindow with less slots. Autoselect usb devive if only one.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,8 @@
 cmake_minimum_required(VERSION 3.5 FATAL_ERROR)
 project(OpenHantekProject)
 
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+
 # Default build type
 IF(NOT CMAKE_CONFIGURATION_TYPES AND NOT CMAKE_BUILD_TYPE)
    SET(CMAKE_BUILD_TYPE RelWithDebInfo)

--- a/openhantek/CMakeLists.txt
+++ b/openhantek/CMakeLists.txt
@@ -1,4 +1,4 @@
-project(OpenHantek CXX C)
+project(OpenHantek CXX)
 
 find_package(Qt5Widgets REQUIRED)
 find_package(Qt5PrintSupport REQUIRED)

--- a/openhantek/src/configdialog/DsoConfigColorsPage.cpp
+++ b/openhantek/src/configdialog/DsoConfigColorsPage.cpp
@@ -4,7 +4,7 @@
 
 DsoConfigColorsPage::DsoConfigColorsPage(DsoSettings *settings, QWidget *parent) : QWidget(parent), settings(settings) {
     // Initialize elements
-    DsoSettingsViewColor &colorSettings = settings->view.color;
+    DsoSettingsView &colorSettings = settings->view;
     enum { COL_LABEL = 0, COL_SCR_CHANNEL, COL_SCR_SPECTRUM, COL_PRT_CHANNEL, COL_PRT_SPECTRUM };
 
     // Plot Area
@@ -127,8 +127,7 @@ DsoConfigColorsPage::DsoConfigColorsPage(DsoSettings *settings, QWidget *parent)
 
 /// \brief Saves the new settings.
 void DsoConfigColorsPage::saveSettings() {
-
-    DsoSettingsViewColor &colorSettings = settings->view.color;
+    DsoSettingsView &colorSettings = settings->view;
 
     // Screen category
     colorSettings.screen.axes = axesColorBox->getColor();

--- a/openhantek/src/configdialog/DsoConfigFilesPage.cpp
+++ b/openhantek/src/configdialog/DsoConfigFilesPage.cpp
@@ -48,7 +48,7 @@ DsoConfigFilesPage::DsoConfigFilesPage(DsoSettings *settings, QWidget *parent) :
 
     setLayout(mainLayout);
 
-    connect(saveNowButton, SIGNAL(clicked()), settings, SLOT(save()));
+    connect(saveNowButton, &QAbstractButton::clicked, [settings]() { settings->save(); });
 }
 
 /// \brief Saves the new settings.

--- a/openhantek/src/dsowidget.cpp
+++ b/openhantek/src/dsowidget.cpp
@@ -24,8 +24,8 @@ DsoWidget::DsoWidget(DsoSettings *settings, QWidget *parent, Qt::WindowFlags fla
 
     // Palette for this widget
     QPalette palette;
-    palette.setColor(QPalette::Background, settings->view.color.screen.background);
-    palette.setColor(QPalette::WindowText, settings->view.color.screen.text);
+    palette.setColor(QPalette::Background, settings->view.screen.background);
+    palette.setColor(QPalette::WindowText, settings->view.screen.text);
 
     // The OpenGL accelerated scope widgets
     zoomScope->setZoomMode(true);
@@ -34,7 +34,7 @@ DsoWidget::DsoWidget(DsoSettings *settings, QWidget *parent, Qt::WindowFlags fla
     offsetSlider = new LevelSlider(Qt::RightArrow);
     for (int channel = 0; channel < settings->scope.voltage.count(); ++channel) {
         offsetSlider->addSlider(settings->scope.voltage[channel].name, channel);
-        offsetSlider->setColor(channel, settings->view.color.screen.voltage[channel]);
+        offsetSlider->setColor(channel, settings->view.screen.voltage[channel]);
         offsetSlider->setLimits(channel, -DIVS_VOLTAGE / 2, DIVS_VOLTAGE / 2);
         offsetSlider->setStep(channel, 0.2);
         offsetSlider->setValue(channel, settings->scope.voltage[channel].offset);
@@ -42,8 +42,7 @@ DsoWidget::DsoWidget(DsoSettings *settings, QWidget *parent, Qt::WindowFlags fla
     }
     for (int channel = 0; channel < settings->scope.voltage.count(); ++channel) {
         offsetSlider->addSlider(settings->scope.spectrum[channel].name, settings->scope.voltage.count() + channel);
-        offsetSlider->setColor(settings->scope.voltage.count() + channel,
-                               settings->view.color.screen.spectrum[channel]);
+        offsetSlider->setColor(settings->scope.voltage.count() + channel, settings->view.screen.spectrum[channel]);
         offsetSlider->setLimits(settings->scope.voltage.count() + channel, -DIVS_VOLTAGE / 2, DIVS_VOLTAGE / 2);
         offsetSlider->setStep(settings->scope.voltage.count() + channel, 0.2);
         offsetSlider->setValue(settings->scope.voltage.count() + channel, settings->scope.spectrum[channel].offset);
@@ -65,8 +64,8 @@ DsoWidget::DsoWidget(DsoSettings *settings, QWidget *parent, Qt::WindowFlags fla
         triggerLevelSlider->setColor(
             channel,
             (!settings->scope.trigger.special && channel == (int)settings->scope.trigger.source)
-                ? settings->view.color.screen.voltage[channel]
-                : settings->view.color.screen.voltage[channel].darker());
+                ? settings->view.screen.voltage[channel]
+                : settings->view.screen.voltage[channel].darker());
         adaptTriggerLevelSlider(channel);
         triggerLevelSlider->setValue(channel, settings->scope.voltage[channel].trigger);
         triggerLevelSlider->setVisible(channel, settings->scope.voltage[channel].used);
@@ -138,7 +137,7 @@ DsoWidget::DsoWidget(DsoSettings *settings, QWidget *parent, Qt::WindowFlags fla
     measurementLayout->setColumnStretch(4, 3);
     measurementLayout->setColumnStretch(5, 3);
     for (int channel = 0; channel < settings->scope.voltage.count(); ++channel) {
-        tablePalette.setColor(QPalette::WindowText, settings->view.color.screen.voltage[channel]);
+        tablePalette.setColor(QPalette::WindowText, settings->view.screen.voltage[channel]);
         measurementNameLabel.append(new QLabel(settings->scope.voltage[channel].name));
         measurementNameLabel[channel]->setPalette(tablePalette);
         measurementMiscLabel.append(new QLabel());
@@ -146,7 +145,7 @@ DsoWidget::DsoWidget(DsoSettings *settings, QWidget *parent, Qt::WindowFlags fla
         measurementGainLabel.append(new QLabel());
         measurementGainLabel[channel]->setAlignment(Qt::AlignRight);
         measurementGainLabel[channel]->setPalette(tablePalette);
-        tablePalette.setColor(QPalette::WindowText, settings->view.color.screen.spectrum[channel]);
+        tablePalette.setColor(QPalette::WindowText, settings->view.screen.spectrum[channel]);
         measurementMagnitudeLabel.append(new QLabel());
         measurementMagnitudeLabel[channel]->setAlignment(Qt::AlignRight);
         measurementMagnitudeLabel[channel]->setPalette(tablePalette);
@@ -280,7 +279,7 @@ void DsoWidget::updateSpectrumDetails(unsigned int channel) {
 void DsoWidget::updateTriggerDetails() {
     // Update the trigger details
     QPalette tablePalette = palette();
-    tablePalette.setColor(QPalette::WindowText, settings->view.color.screen.voltage[settings->scope.trigger.source]);
+    tablePalette.setColor(QPalette::WindowText, settings->view.screen.voltage[settings->scope.trigger.source]);
     settingsTriggerLabel->setPalette(tablePalette);
     QString levelString = valueToString(settings->scope.voltage[settings->scope.trigger.source].trigger, UNIT_VOLTS, 3);
     QString pretriggerString = tr("%L1%").arg((int)(settings->scope.trigger.position * 100 + 0.5));
@@ -350,16 +349,16 @@ void DsoWidget::updateTriggerSlope() { updateTriggerDetails(); }
 void DsoWidget::updateTriggerSource() {
     // Change the colors of the trigger sliders
     if (settings->scope.trigger.special || settings->scope.trigger.source >= settings->scope.physicalChannels)
-        triggerPositionSlider->setColor(0, settings->view.color.screen.border);
+        triggerPositionSlider->setColor(0, settings->view.screen.border);
     else
-        triggerPositionSlider->setColor(0, settings->view.color.screen.voltage[settings->scope.trigger.source]);
+        triggerPositionSlider->setColor(0, settings->view.screen.voltage[settings->scope.trigger.source]);
 
     for (int channel = 0; channel < (int)settings->scope.physicalChannels; ++channel)
         triggerLevelSlider->setColor(
             channel,
             (!settings->scope.trigger.special && channel == (int)settings->scope.trigger.source)
-                ? settings->view.color.screen.voltage[channel]
-                : settings->view.color.screen.voltage[channel].darker());
+                ? settings->view.screen.voltage[channel]
+                : settings->view.screen.voltage[channel].darker());
 
     updateTriggerDetails();
 }

--- a/openhantek/src/exporter.cpp
+++ b/openhantek/src/exporter.cpp
@@ -69,9 +69,9 @@ bool Exporter::exportSamples(const DataAnalyzerResult *result) {
     // Choose the color values we need
     DsoSettingsColorValues *colorValues;
     if (this->format == EXPORT_FORMAT_IMAGE && settings->view.screenColorImages)
-        colorValues = &(settings->view.color.screen);
+        colorValues = &(settings->view.screen);
     else
-        colorValues = &(settings->view.color.print);
+        colorValues = &(settings->view.print);
 
     std::unique_ptr<QPaintDevice> paintDevice;
 

--- a/openhantek/src/glscope.cpp
+++ b/openhantek/src/glscope.cpp
@@ -22,7 +22,7 @@ void GlScope::initializeGL() {
 
     glPointSize(1);
 
-    QColor bg = settings->view.color.screen.background;
+    QColor bg = settings->view.screen.background;
     glClearColor(bg.redF(), bg.greenF(), bg.blueF(), bg.alphaF());
 
     glShadeModel(GL_SMOOTH /*GL_FLAT*/);
@@ -33,18 +33,16 @@ void GlScope::initializeGL() {
 
 /// \brief Draw the graphs and the grid.
 void GlScope::paintGL() {
-    if (!isVisible() || !generator->isReady()) return;
-
     // Clear OpenGL buffer and configure settings
     glClear(GL_COLOR_BUFFER_BIT);
     glLineWidth(1);
 
-    if (settings->view.digitalPhosphorDepth > 0) { drawGraph(); }
+    if (settings->view.digitalPhosphorDepth > 0 && generator->isReady()) { drawGraph(); }
 
     if (!this->zoomed) {
         // Draw vertical lines at marker positions
         glEnable(GL_LINE_STIPPLE);
-        QColor trColor = settings->view.color.screen.markers;
+        QColor trColor = settings->view.screen.markers;
         glColor4f(trColor.redF(), trColor.greenF(), trColor.blueF(), trColor.alphaF());
 
         for (int marker = 0; marker < MARKER_COUNT; ++marker) {
@@ -99,17 +97,17 @@ void GlScope::drawGrid() {
 
     QColor color;
     // Grid
-    color = settings->view.color.screen.grid;
+    color = settings->view.screen.grid;
     glColor4f(color.redF(), color.greenF(), color.blueF(), color.alphaF());
     glVertexPointer(2, GL_FLOAT, 0, &generator->grid(0).front());
     glDrawArrays(GL_POINTS, 0, generator->grid(0).size() / 2);
     // Axes
-    color = settings->view.color.screen.axes;
+    color = settings->view.screen.axes;
     glColor4f(color.redF(), color.greenF(), color.blueF(), color.alphaF());
     glVertexPointer(2, GL_FLOAT, 0, &generator->grid(1).front());
     glDrawArrays(GL_LINES, 0, generator->grid(1).size() / 2);
     // Border
-    color = settings->view.color.screen.border;
+    color = settings->view.screen.border;
     glColor4f(color.redF(), color.greenF(), color.blueF(), color.alphaF());
     glVertexPointer(2, GL_FLOAT, 0, &generator->grid(2).front());
     glDrawArrays(GL_LINE_LOOP, 0, generator->grid(2).size() / 2);
@@ -119,9 +117,9 @@ void GlScope::drawGraphDepth(int mode, int channel, int index) {
     if (generator->channel(mode, channel, index).empty()) return;
     QColor trColor;
     if (mode == Dso::CHANNELMODE_VOLTAGE)
-        trColor = settings->view.color.screen.voltage[channel].darker(fadingFactor[index]);
+        trColor = settings->view.screen.voltage[channel].darker(fadingFactor[index]);
     else
-        trColor = settings->view.color.screen.spectrum[channel].darker(fadingFactor[index]);
+        trColor = settings->view.screen.spectrum[channel].darker(fadingFactor[index]);
     glColor4f(trColor.redF(), trColor.greenF(), trColor.blueF(), trColor.alphaF());
     glVertexPointer(2, GL_FLOAT, 0, &generator->channel(mode, channel, index).front());
     glDrawArrays((settings->view.interpolation == Dso::INTERPOLATION_OFF) ? GL_POINTS : GL_LINE_STRIP, 0,

--- a/openhantek/src/hantek/hantekdsocontrol.cpp
+++ b/openhantek/src/hantek/hantekdsocontrol.cpp
@@ -373,7 +373,7 @@ HantekDsoControl::HantekDsoControl(USBDevice *device) : device(device) {
 
     // Get channel level data
     errorCode = device->controlRead(CONTROL_VALUE, (unsigned char *)&(specification.offsetLimit),
-                                          sizeof(specification.offsetLimit), (int)VALUE_OFFSETLIMITS);
+                                    sizeof(specification.offsetLimit), (int)VALUE_OFFSETLIMITS);
     if (errorCode < 0) {
         device->disconnect();
         emit statusMessage(tr("Couldn't get channel level data from oscilloscope"), 0);
@@ -386,9 +386,7 @@ HantekDsoControl::HantekDsoControl(USBDevice *device) : device(device) {
 /// \brief Disconnects the device.
 HantekDsoControl::~HantekDsoControl() {
     // Clean up commands
-    for (int cIndex = 0; cIndex < BULK_COUNT; ++cIndex) {
-        delete command[cIndex];
-    }
+    for (int cIndex = 0; cIndex < BULK_COUNT; ++cIndex) { delete command[cIndex]; }
 }
 
 /// \brief Gets the physical channel count for this oscilloscope.
@@ -397,9 +395,7 @@ unsigned HantekDsoControl::getChannelCount() { return HANTEK_CHANNELS; }
 
 /// \brief Get available record lengths for this oscilloscope.
 /// \return The number of physical channels, empty list for continuous.
-QList<unsigned> *HantekDsoControl::getAvailableRecordLengths() {
-    return &settings.samplerate.limits->recordLengths;
-}
+QList<unsigned> *HantekDsoControl::getAvailableRecordLengths() { return &settings.samplerate.limits->recordLengths; }
 
 /// \brief Get minimum samplerate for this oscilloscope.
 /// \return The minimum samplerate for the current configuration in S/s.
@@ -547,7 +543,7 @@ int HantekDsoControl::getSamples(bool process) {
                 // Additional most significant bits after the normal data
                 unsigned extraBitsPosition; // Track the position of the extra
                 // bits in the additional byte
-                unsigned extraBitsSize = specification.sampleSize - 8;             // Number of extra bits
+                unsigned extraBitsSize = specification.sampleSize - 8;                 // Number of extra bits
                 unsigned short int extraBitsMask = (0x00ff << extraBitsSize) & 0xff00; // Mask for extra bits extraction
 
                 for (unsigned realPosition = 0; realPosition < sampleCount; ++realPosition, ++bufferPosition) {
@@ -597,7 +593,7 @@ int HantekDsoControl::getSamples(bool process) {
                     // Additional most significant bits after the normal data
                     unsigned extraBitsSize = specification.sampleSize - 8; // Number of extra bits
                     unsigned short int extraBitsMask =
-                        (0x00ff << extraBitsSize) & 0xff00;        // Mask for extra bits extraction
+                        (0x00ff << extraBitsSize) & 0xff00;    // Mask for extra bits extraction
                     unsigned extraBitsIndex = 8 - channel * 2; // Bit position offset for extra bits extraction
 
                     for (unsigned realPosition = 0; realPosition < sampleCount;
@@ -1451,8 +1447,7 @@ double HantekDsoControl::setPretriggerPosition(double position) {
         unsigned position = isRollMode() ? 0x1 : 0x7ffff - recordLength + positionSamples;
 
         // SetTriggerAndSamplerate bulk command for trigger position
-        static_cast<BulkSetTriggerAndSamplerate *>(command[BULK_SETTRIGGERANDSAMPLERATE])
-            ->setTriggerPosition(position);
+        static_cast<BulkSetTriggerAndSamplerate *>(command[BULK_SETTRIGGERANDSAMPLERATE])->setTriggerPosition(position);
         commandPending[BULK_SETTRIGGERANDSAMPLERATE] = true;
 
         break;
@@ -1491,19 +1486,16 @@ double HantekDsoControl::setPretriggerPosition(double position) {
     return (double)positionSamples / settings.samplerate.current;
 }
 
-int HantekDsoControl::stringCommand(const QString& commandString) {
+int HantekDsoControl::stringCommand(const QString &commandString) {
     if (!device->isConnected()) return Dso::ERROR_CONNECTION;
 
     QStringList commandParts = commandString.split(' ', QString::SkipEmptyParts);
 
-    if (commandParts.count() < 1)
-        return Dso::ERROR_PARAMETER;
+    if (commandParts.count() < 1) return Dso::ERROR_PARAMETER;
 
-    if (commandParts[0] != "send")
-        return Dso::ERROR_UNSUPPORTED;
+    if (commandParts[0] != "send") return Dso::ERROR_UNSUPPORTED;
 
-    if (commandParts.count() < 2)
-        return Dso::ERROR_PARAMETER;
+    if (commandParts.count() < 2) return Dso::ERROR_PARAMETER;
 
     if (commandParts[1] == "bulk") {
         QString data = commandString.section(' ', 2, -1, QString::SectionSkipEmpty);
@@ -1545,13 +1537,12 @@ void HantekDsoControl::run() {
     for (int cIndex = 0; cIndex < BULK_COUNT; ++cIndex) {
         if (!commandPending[cIndex]) continue;
 
-        timestampDebug(QString("Sending bulk command:%1")
-                           .arg(hexDump(command[cIndex]->data(), command[cIndex]->getSize())));
+        timestampDebug(
+            QString("Sending bulk command:%1").arg(hexDump(command[cIndex]->data(), command[cIndex]->getSize())));
 
         errorCode = device->bulkCommand(command[cIndex]);
         if (errorCode < 0) {
-            qWarning("Sending bulk command %02x failed: %s", cIndex,
-                     libUsbErrorString(errorCode).toLocal8Bit().data());
+            qWarning("Sending bulk command %02x failed: %s", cIndex, libUsbErrorString(errorCode).toLocal8Bit().data());
 
             if (errorCode == LIBUSB_ERROR_NO_DEVICE) {
                 emit communicationError();
@@ -1570,7 +1561,7 @@ void HantekDsoControl::run() {
                                 hexDump(this->control[control]->data(), this->control[control]->getSize())));
 
         errorCode = device->controlWrite(this->controlCode[cIndex], this->control[cIndex]->data(),
-                                               this->control[cIndex]->getSize());
+                                         this->control[cIndex]->getSize());
         if (errorCode < 0) {
             qWarning("Sending control command %2x failed: %s", this->controlCode[cIndex],
                      libUsbErrorString(errorCode).toLocal8Bit().data());

--- a/openhantek/src/hantek/hantekdsocontrol.h
+++ b/openhantek/src/hantek/hantekdsocontrol.h
@@ -67,7 +67,7 @@ class HantekDsoControl : public QObject {
     void samplesAvailable();                                 ///< New sample data is available
 
     void availableRecordLengthsChanged(const QList<unsigned> &recordLengths); ///< The available record
-                                                                                  /// lengths, empty list for
+                                                                              /// lengths, empty list for
     /// continuous
     void samplerateLimitsChanged(double minimum, double maximum); ///< The minimum or maximum samplerate has changed
     void recordLengthChanged(unsigned long duration);             ///< The record length has changed
@@ -84,8 +84,7 @@ class HantekDsoControl : public QObject {
     unsigned calculateTriggerPoint(unsigned value);
     int getCaptureState();
     int getSamples(bool process);
-    double getBestSamplerate(double samplerate, bool fastRate = false, bool maximum = false,
-                             unsigned *downsampler = 0);
+    double getBestSamplerate(double samplerate, bool fastRate = false, bool maximum = false, unsigned *downsampler = 0);
     unsigned getSampleCount(bool *fastRate = 0);
     unsigned updateRecordLength(unsigned size);
     unsigned updateSamplerate(unsigned downsampler, bool fastRate);
@@ -93,8 +92,8 @@ class HantekDsoControl : public QObject {
     void updateSamplerateLimits();
 
     // Communication with device
-    USBDevice *device; ///< The USB device for the oscilloscope
-    bool sampling = false;     ///< true, if the oscilloscope is taking samples
+    USBDevice *device;     ///< The USB device for the oscilloscope
+    bool sampling = false; ///< true, if the oscilloscope is taking samples
 
     QStringList specialTriggerSources; ///< Names of the special trigger sources
 
@@ -116,7 +115,7 @@ class HantekDsoControl : public QObject {
     // Results
     DSOsamples result;
     unsigned previousSampleCount; ///< The expected total number of samples at
-                                      /// the last check before sampling started
+                                  /// the last check before sampling started
 
     // State of the communication thread
     int captureState = Hantek::CAPTURE_WAITING;

--- a/openhantek/src/hantek/usb/usbdevice.cpp
+++ b/openhantek/src/hantek/usb/usbdevice.cpp
@@ -18,6 +18,7 @@ USBDevice::USBDevice(DSOModel model, libusb_device *device) : model(model), devi
 
 bool USBDevice::connectDevice(QString &errorMessage) {
     if (needsFirmware()) return false;
+    if (isConnected()) return true;
 
     // Open device
     int errorCode = libusb_open(device, &(handle));

--- a/openhantek/src/hantek/usb/usbdevice.h
+++ b/openhantek/src/hantek/usb/usbdevice.h
@@ -79,7 +79,6 @@ class USBDevice : public QObject {
     int interface;
     int outPacketLength; ///< Packet length for the OUT endpoint
     int inPacketLength;  ///< Packet length for the IN endpoint
-
   signals:
     void deviceDisconnected(); ///< The device has been disconnected
 };

--- a/openhantek/src/mainwindow.h
+++ b/openhantek/src/mainwindow.h
@@ -27,7 +27,7 @@ class OpenHantekMainWindow : public QMainWindow {
     Q_OBJECT
 
   public:
-    OpenHantekMainWindow(HantekDsoControl *dsoControl, DataAnalyzer *dataAnalyser);
+    OpenHantekMainWindow(HantekDsoControl *dsoControl, DataAnalyzer *dataAnalyser, DsoSettings *settings);
 
   protected:
     void closeEvent(QCloseEvent *event);
@@ -80,26 +80,16 @@ class OpenHantekMainWindow : public QMainWindow {
     HantekDsoControl *dsoControl;
     DataAnalyzer *dataAnalyzer;
 
-    // Other variables
-    QString currentFile;
-
     // Settings used for the whole program
     DsoSettings *settings;
 
   private slots:
-    // File operations
-    void open();
-    void save();
-    void saveAs();
     // View
     void digitalPhosphor(bool enabled);
     void zoom(bool enabled);
     // Oscilloscope control
     void started();
     void stopped();
-    // Other
-    void config();
-    void about();
 
     // Settings management
     void applySettings();

--- a/openhantek/src/scopesettings.h
+++ b/openhantek/src/scopesettings.h
@@ -1,32 +1,32 @@
 #pragma once
 
 #include "definitions.h"
-#include <QList>
+#include <QVector>
 
 ////////////////////////////////////////////////////////////////////////////////
 /// \struct DsoSettingsScopeHorizontal                                settings.h
 /// \brief Holds the settings for the horizontal axis.
 struct DsoSettingsScopeHorizontal {
-    Dso::GraphFormat format;     ///< Graph drawing mode of the scope
-    double frequencybase;        ///< Frequencybase in Hz/div
-    double marker[MARKER_COUNT]; ///< Marker positions in div
+    Dso::GraphFormat format = Dso::GRAPHFORMAT_TY; ///< Graph drawing mode of the scope
+    double frequencybase = 1e3;                    ///< Frequencybase in Hz/div
+    double marker[MARKER_COUNT] = {-1.0, 1.0};     ///< Marker positions in div
     bool marker_visible[MARKER_COUNT];
-    double timebase;           ///< Timebase in s/div
-    unsigned int recordLength; ///< Sample count
-    double samplerate;         ///< The samplerate of the oscilloscope in S
-    bool samplerateSet;        ///< The samplerate was set by the user, not the timebase
+    double timebase = 1e-3;        ///< Timebase in s/div
+    unsigned int recordLength = 0; ///< Sample count
+    double samplerate = 1e6;       ///< The samplerate of the oscilloscope in S
+    bool samplerateSet = false;    ///< The samplerate was set by the user, not the timebase
 };
 
 ////////////////////////////////////////////////////////////////////////////////
 /// \struct DsoSettingsScopeTrigger                                   settings.h
 /// \brief Holds the settings for the trigger.
 struct DsoSettingsScopeTrigger {
-    bool filter;           ///< Not sure what this is good for...
-    Dso::TriggerMode mode; ///< Automatic, normal or single trigger
-    double position;       ///< Horizontal position for pretrigger
-    Dso::Slope slope;      ///< Rising or falling edge causes trigger
-    unsigned int source;   ///< Channel that is used as trigger source
-    bool special;          ///< true if the trigger source is not a standard channel
+    bool filter = true;                              ///< Not sure what this is good for...
+    Dso::TriggerMode mode = Dso::TRIGGERMODE_NORMAL; ///< Automatic, normal or single trigger
+    double position = 0.0;                           ///< Horizontal position for pretrigger
+    Dso::Slope slope = Dso::SLOPE_POSITIVE;          ///< Rising or falling edge causes trigger
+    unsigned int source = 0;                         ///< Channel that is used as trigger source
+    bool special = false;                            ///< true if the trigger source is not a standard channel
 };
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -57,11 +57,11 @@ struct DsoSettingsScopeVoltage {
 struct DsoSettingsScope {
     DsoSettingsScopeHorizontal horizontal;    ///< Settings for the horizontal axis
     DsoSettingsScopeTrigger trigger;          ///< Settings for the trigger
-    QList<DsoSettingsScopeSpectrum> spectrum; ///< Spectrum analysis settings
-    QList<DsoSettingsScopeVoltage> voltage;   ///< Settings for the normal graphs
+    QVector<DsoSettingsScopeSpectrum> spectrum; ///< Spectrum analysis settings
+    QVector<DsoSettingsScopeVoltage> voltage;   ///< Settings for the normal graphs
 
-    unsigned int physicalChannels;      ///< Number of real channels (No math etc.)
-    Dso::WindowFunction spectrumWindow; ///< Window function for DFT
-    double spectrumReference;           ///< Reference level for spectrum in dBm
-    double spectrumLimit;               ///< Minimum magnitude of the spectrum (Avoids peaks)
+    unsigned int physicalChannels = 0;                     ///< Number of real channels (No math etc.)
+    Dso::WindowFunction spectrumWindow = Dso::WINDOW_HANN; ///< Window function for DFT
+    double spectrumReference = 0.0;                        ///< Reference level for spectrum in dBm
+    double spectrumLimit = -20.0;                          ///< Minimum magnitude of the spectrum (Avoids peaks)
 };

--- a/openhantek/src/settings.h
+++ b/openhantek/src/settings.h
@@ -2,28 +2,29 @@
 
 #pragma once
 
+#include <QSettings>
 #include <QSize>
 #include <QString>
+#include <memory>
 
 #include "scopesettings.h"
 #include "viewsettings.h"
 
 ////////////////////////////////////////////////////////////////////////////////
-/// \struct DsoSettingsOptions                                        settings.h
+/// \struct DsoSettingsOptions
 /// \brief Holds the general options of the program.
 struct DsoSettingsOptions {
-    bool alwaysSave; ///< Always save the settings on exit
-    QSize imageSize; ///< Size of exported images in pixels
+    bool alwaysSave = true;            ///< Always save the settings on exit
+    QSize imageSize = QSize(640, 480); ///< Size of exported images in pixels
 };
 
 ////////////////////////////////////////////////////////////////////////////////
-/// \class DsoSettings                                                settings.h
+/// \class DsoSettings
 /// \brief Holds the settings of the program.
-class DsoSettings : public QObject {
-    Q_OBJECT
-
+class DsoSettings {
   public:
-    DsoSettings(QWidget *parent = 0);
+    DsoSettings();
+    bool setFilename(const QString &filename);
 
     void setChannelCount(unsigned int channels);
 
@@ -34,8 +35,12 @@ class DsoSettings : public QObject {
     QByteArray mainWindowGeometry; ///< Geometry of the main window
     QByteArray mainWindowState;    ///< State of docking windows and toolbars
 
-  public slots:
-    // Saving to and loading from configuration files
-    int load(const QString &fileName = QString());
-    int save(const QString &fileName = QString());
+    /// \brief Read the settings from the last session or another file.
+    void load();
+
+    /// \brief Save the settings to the harddisk.
+    void save();
+
+  private:
+    std::unique_ptr<QSettings> store = std::unique_ptr<QSettings>(new QSettings);
 };

--- a/openhantek/src/viewconstants.h
+++ b/openhantek/src/viewconstants.h
@@ -3,4 +3,3 @@
 #define DIVS_TIME 10.0   ///< Number of horizontal screen divs
 #define DIVS_VOLTAGE 8.0 ///< Number of vertical screen divs
 #define DIVS_SUB 5       ///< Number of sub-divisions per div
-

--- a/openhantek/src/viewsettings.h
+++ b/openhantek/src/viewsettings.h
@@ -2,42 +2,49 @@
 
 #include "definitions.h"
 #include <QColor>
-#include <QList>
 #include <QObject>
 #include <QPoint>
 #include <QString>
+#include <QVector>
 
 ////////////////////////////////////////////////////////////////////////////////
-/// \struct DsoSettingsColorValues                                    settings.h
+/// \struct DsoSettingsColorValues
 /// \brief Holds the color values for the oscilloscope screen.
 struct DsoSettingsColorValues {
-    QColor axes;            ///< X- and Y-axis and subdiv lines on them
-    QColor background;      ///< The scope background
-    QColor border;          ///< The border of the scope screen
-    QColor grid;            ///< The color of the grid
-    QColor markers;         ///< The color of the markers
-    QList<QColor> spectrum; ///< The colors of the spectrum graphs
-    QColor text;            ///< The default text color
-    QList<QColor> voltage;  ///< The colors of the voltage graphs
+    QColor axes;              ///< X- and Y-axis and subdiv lines on them
+    QColor background;        ///< The scope background
+    QColor border;            ///< The border of the scope screen
+    QColor grid;              ///< The color of the grid
+    QColor markers;           ///< The color of the markers
+    QColor text;              ///< The default text color
+    QVector<QColor> spectrum; ///< The colors of the spectrum graphs
+    QVector<QColor> voltage;  ///< The colors of the voltage graphs
 };
 
 ////////////////////////////////////////////////////////////////////////////////
-/// \struct DsoSettingsViewColor                                      settings.h
-/// \brief Holds the settings for the used colors on the screen and on paper.
-struct DsoSettingsViewColor {
-    DsoSettingsColorValues screen; ///< Colors for the screen
-    DsoSettingsColorValues print;  ///< Colors for printout
-};
-
-////////////////////////////////////////////////////////////////////////////////
-/// \struct DsoSettingsView                                           settings.h
+/// \struct DsoSettingsView
 /// \brief Holds all view settings.
 struct DsoSettingsView {
-    DsoSettingsViewColor color;           ///< Used colors
-    bool antialiasing;                    ///< Antialiasing for the graphs
-    bool digitalPhosphor;                 ///< true slowly fades out the previous graphs
-    int digitalPhosphorDepth;             ///< Number of channels shown at one time
-    Dso::InterpolationMode interpolation; ///< Interpolation mode for the graph
-    bool screenColorImages;               ///< true exports images with screen colors
-    bool zoom;                            ///< true if the magnified scope is enabled
+    DsoSettingsColorValues screen = {QColor(0xff, 0xff, 0xff, 0x7f),
+                                     QColor(0x00, 0x00, 0x00, 0xff),
+                                     QColor(0xff, 0xff, 0xff, 0xff),
+                                     QColor(0xff, 0xff, 0xff, 0x3f),
+                                     QColor(0xff, 0xff, 0xff, 0xbf),
+                                     QColor(0xff, 0xff, 0xff, 0xff),
+                                     QVector<QColor>(),
+                                     QVector<QColor>()};
+    DsoSettingsColorValues print = {QColor(0x00, 0x00, 0x00, 0xbf),
+                                    QColor(0x00, 0x00, 0x00, 0x00),
+                                    QColor(0x00, 0x00, 0x00, 0xff),
+                                    QColor(0x00, 0x00, 0x00, 0x7f),
+                                    QColor(0x00, 0x00, 0x00, 0xef),
+                                    QColor(0x00, 0x00, 0x00, 0xff),
+                                    QVector<QColor>(),
+                                    QVector<QColor>()};
+    bool antialiasing = true;                                         ///< Antialiasing for the graphs
+    bool digitalPhosphor = false;                                     ///< true slowly fades out the previous graphs
+    int digitalPhosphorDepth = 8;                                     ///< Number of channels shown at one time
+    Dso::InterpolationMode interpolation = Dso::INTERPOLATION_LINEAR; ///< Interpolation mode for the graph
+    bool screenColorImages = false;                                   ///< true exports images with screen colors
+    bool zoom = false;                                                ///< true if the magnified scope is enabled
 };


### PR DESCRIPTION
Settings:
* Create settings object in main.cpp already
* Reduce code in settings.h/cpp by using c++11 class field initalisations
* Remove unnessesary color class
* Use a permanent QSettings object and introduce a setFilename method.

Bigger scope:
MainWindow was responsible to create all kind of important objects like the
DataAnalyser, the DSOControl and also the settings object. Finally it is
only responsible for assembling the main graphical interface window and
all DSO related objects are created in main. This way the current GUI can
be more easily replaced with a modern or even headless variant.