### PR TITLE
Concentrate model implementation differences to hantekdsocontrol class

### DIFF
--- a/openhantek/src/hantek/hantekdsocontrol.h
+++ b/openhantek/src/hantek/hantekdsocontrol.h
@@ -95,26 +95,26 @@ class HantekDsoControl : public QObject {
     USBDevice *device;     ///< The USB device for the oscilloscope
     bool sampling = false; ///< true, if the oscilloscope is taking samples
 
-    QStringList specialTriggerSources; ///< Names of the special trigger sources
+    QStringList specialTriggerSources = {tr("EXT"),tr("EXT/10")}; ///< Names of the special trigger sources
 
-    DataArray<unsigned char> *command[Hantek::BULK_COUNT]; ///< Pointers to bulk
+    DataArray<unsigned char> *command[Hantek::BULK_COUNT] = {0}; ///< Pointers to bulk
                                                            /// commands, ready to
     /// be transmitted
-    bool commandPending[Hantek::BULK_COUNT];                       ///< true, when the command should be
+    bool commandPending[Hantek::BULK_COUNT] = {false};                       ///< true, when the command should be
                                                                    /// executed
-    DataArray<unsigned char> *control[Hantek::CONTROLINDEX_COUNT]; ///< Pointers to control commands
+    DataArray<unsigned char> *control[Hantek::CONTROLINDEX_COUNT] = {0}; ///< Pointers to control commands
     unsigned char controlCode[Hantek::CONTROLINDEX_COUNT];         ///< Request codes for
                                                                    /// control commands
-    bool controlPending[Hantek::CONTROLINDEX_COUNT];               ///< true, when the control
+    bool controlPending[Hantek::CONTROLINDEX_COUNT]= {false};               ///< true, when the control
     /// command should be executed
 
     // Device setup
     Hantek::ControlSpecification specification; ///< The specifications of the device
-    Hantek::ControlSettings settings;           ///< The current settings of the device
+    Hantek::ControlSettings controlsettings;           ///< The current settings of the device
 
     // Results
     DSOsamples result;
-    unsigned previousSampleCount; ///< The expected total number of samples at
+    unsigned previousSampleCount = 0; ///< The expected total number of samples at
                                   /// the last check before sampling started
 
     // State of the communication thread
@@ -125,6 +125,7 @@ class HantekDsoControl : public QObject {
     int cycleCounter = 0;
     int startCycle = 0;
     int cycleTime = 0;
+
   public slots:
     void startSampling();
     void stopSampling();

--- a/openhantek/src/hantek/stateStructs.h
+++ b/openhantek/src/hantek/stateStructs.h
@@ -115,6 +115,12 @@ struct ControlSpecification {
     /// Calibration data for the channel offsets \todo Should probably be a QList
     /// too
     unsigned short int offsetLimit[HANTEK_CHANNELS][9][OFFSET_COUNT];
+
+    bool isSoftwareTriggerDevice=false;
+    bool useControlNoBulk = false;
+    bool supportsCaptureState = true;
+    bool supportsOffset = true;
+    bool supportsCouplingRelays = true;
 };
 
 //////////////////////////////////////////////////////////////////////////////

--- a/openhantek/src/hantek/usb/usbdevice.cpp
+++ b/openhantek/src/hantek/usb/usbdevice.cpp
@@ -75,8 +75,7 @@ int USBDevice::claimInterface(const libusb_interface_descriptor *interfaceDescri
         if (endpointDescriptor->bEndpointAddress == endpointOut) {
             this->outPacketLength = endpointDescriptor->wMaxPacketSize;
         } else if (endpointDescriptor->bEndpointAddress == endPointIn) {
-            this->inPacketLength =
-                (model.uniqueModelID == MODEL_DSO6022BE) ? 16384 : endpointDescriptor->wMaxPacketSize;
+            this->inPacketLength = endpointDescriptor->wMaxPacketSize;
         }
     }
     return LIBUSB_SUCCESS;
@@ -155,8 +154,7 @@ int USBDevice::bulkRead(unsigned char *data, unsigned int length, int attempts) 
 int USBDevice::bulkCommand(DataArray<unsigned char> *command, int attempts) {
     if (!this->handle) return LIBUSB_ERROR_NO_DEVICE;
 
-    // don't send bulk command if dso6022be
-    if (this->getUniqueModelID() == MODEL_DSO6022BE) return 0;
+    if (!allowBulkTransfer) return LIBUSB_SUCCESS;
 
     // Send BeginCommand control command
     int errorCode = this->controlWrite(CONTROL_BEGINCOMMAND, this->beginCommandControl->data(),
@@ -283,3 +281,13 @@ int USBDevice::getUniqueModelID() { return model.uniqueModelID; }
 libusb_device *USBDevice::getRawDevice() const { return device; }
 
 const DSOModel &USBDevice::getModel() const { return model; }
+
+void USBDevice::setEnableBulkTransfer(bool enable)
+{
+    allowBulkTransfer = enable;
+}
+
+void USBDevice::overwriteInPacketLength(int len)
+{
+    inPacketLength = len;
+}

--- a/openhantek/src/hantek/usb/usbdevice.h
+++ b/openhantek/src/hantek/usb/usbdevice.h
@@ -63,6 +63,8 @@ class USBDevice : public QObject {
 
     libusb_device *getRawDevice() const;
     const DSOModel &getModel() const;
+    void setEnableBulkTransfer(bool enable);
+    void overwriteInPacketLength(int len);
 
   protected:
     int claimInterface(const libusb_interface_descriptor *interfaceDescriptor, int endpointOut, int endPointIn);
@@ -79,6 +81,7 @@ class USBDevice : public QObject {
     int interface;
     int outPacketLength; ///< Packet length for the OUT endpoint
     int inPacketLength;  ///< Packet length for the IN endpoint
+    bool allowBulkTransfer = true;
   signals:
     void deviceDisconnected(); ///< The device has been disconnected
 };


### PR DESCRIPTION
* Remove usbdevice special case for the 6022 model and introduce a feature flag instead.
* Remove all specific model checks across the hantekdsocontrol class and introduce feature flags instead.

Bigger picture: All model differences should be described in the controlsettings and specification structures
within the constructor of hantekdsocontrol. The rest of the class should be model independant code or marked as
very model dependant code. This should allow to split the class into smaller parts to realize Separation of concerns.

TODO: getSamples() has basically two code paths: One for the 6022Bx and one for all other devices.
I suggest getSamples() and getSamples6022Bx() for instance.