### PR TITLE
Hantekdsocontrol

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,17 +11,17 @@ addons:
   apt:
     sources:
     - ubuntu-toolchain-r-test
-    - llvm-toolchain-trusty-3.6
+    - llvm-toolchain-trusty-3.9
     packages: &native_deps
     - cmake
     - libusb-1.0-0-dev
     - libfftw3-dev
-    - libqt5qml5
+#    - libqt5qml5
     - libgtest-dev
-    - libqt5opengl5-dev
-    - qtbase5-dev
-    - qttools5-dev
-    - qttools5-dev-tools
+#    - libqt5opengl5-dev
+#    - qtbase5-dev
+#    - qttools5-dev
+#    - qttools5-dev-tools
     - gcc-5
     - g++-5
 #    - doxygen
@@ -44,9 +44,12 @@ matrix:
   
 before_install:
     - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew update; brew install libusb fftw qt5; export CMAKE_PREFIX_PATH=$(brew --prefix qt5); fi
-    - if [[ "$TRAVIS_OS_NAME" != "osx" ]]; then mkdir $HOME/usr; export PATH="$HOME/usr/bin:$PATH"; wget https://cmake.org/files/v3.7/cmake-3.7.2-Linux-x86_64.sh; chmod +x cmake-3.7.2-Linux-x86_64.sh; ./cmake-3.7.2-Linux-x86_64.sh --prefix=$HOME/usr --exclude-subdir --skip-license; fi
+    - if [[ "$TRAVIS_OS_NAME" != "osx" ]]; then sudo add-apt-repository ppa:beineri/opt-qt551-trusty;sudo apt-get -qq update; sudo apt-get --yes install qt55base; fi
 
 before_script:
+    - QTDIR="/opt/qt55"
+    - PATH="$QTDIR/bin:$PATH"
+    - source /opt/qt55/bin/qt55-env.sh
     - mkdir build
     - cd build
     - cmake -DCMAKE_CXX_COMPILER=$CMAKE_CXX_COMPILER -DCMAKE_PREFIX_PATH=$CMAKE_PREFIX_PATH ../

--- a/.travis.yml
+++ b/.travis.yml
@@ -44,12 +44,9 @@ matrix:
   
 before_install:
     - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew update; brew install libusb fftw qt5; export CMAKE_PREFIX_PATH=$(brew --prefix qt5); fi
-    - if [[ "$TRAVIS_OS_NAME" != "osx" ]]; then sudo add-apt-repository -y ppa:beineri/opt-qt542-trusty;sudo apt-get -qq update; sudo apt-get --yes install -qq qt54base; fi
+    - if [[ "$TRAVIS_OS_NAME" != "osx" ]]; then sudo add-apt-repository -y ppa:beineri/opt-qt542-trusty;sudo apt-get -qq update; sudo apt-get --yes install -qq qt54base; QTDIR="/opt/qt55"; PATH="$QTDIR/bin:$PATH"; source /opt/qt54/bin/qt54-env.sh; fi
 
 before_script:
-    - QTDIR="/opt/qt55"
-    - PATH="$QTDIR/bin:$PATH"
-    - source /opt/qt54/bin/qt54-env.sh
     - mkdir build
     - cd build
     - cmake -DCMAKE_CXX_COMPILER=$CMAKE_CXX_COMPILER -DCMAKE_PREFIX_PATH=$CMAKE_PREFIX_PATH ../

--- a/.travis.yml
+++ b/.travis.yml
@@ -44,7 +44,7 @@ matrix:
   
 before_install:
     - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew update; brew install libusb fftw qt5; export CMAKE_PREFIX_PATH=$(brew --prefix qt5); fi
-    - if [[ "$TRAVIS_OS_NAME" != "osx" ]]; then sudo add-apt-repository ppa:beineri/opt-qt542-trusty;sudo apt-get -qq update; sudo apt-get --yes install -qq qt54base; fi
+    - if [[ "$TRAVIS_OS_NAME" != "osx" ]]; then sudo add-apt-repository -y ppa:beineri/opt-qt542-trusty;sudo apt-get -qq update; sudo apt-get --yes install -qq qt54base; fi
 
 before_script:
     - QTDIR="/opt/qt55"

--- a/.travis.yml
+++ b/.travis.yml
@@ -44,12 +44,12 @@ matrix:
   
 before_install:
     - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew update; brew install libusb fftw qt5; export CMAKE_PREFIX_PATH=$(brew --prefix qt5); fi
-    - if [[ "$TRAVIS_OS_NAME" != "osx" ]]; then sudo add-apt-repository ppa:beineri/opt-qt551-trusty;sudo apt-get -qq update; sudo apt-get --yes install qt55base; fi
+    - if [[ "$TRAVIS_OS_NAME" != "osx" ]]; then sudo add-apt-repository ppa:beineri/opt-qt542-trusty;sudo apt-get -qq update; sudo apt-get --yes install -qq qt54base; fi
 
 before_script:
     - QTDIR="/opt/qt55"
     - PATH="$QTDIR/bin:$PATH"
-    - source /opt/qt55/bin/qt55-env.sh
+    - source /opt/qt54/bin/qt54-env.sh
     - mkdir build
     - cd build
     - cmake -DCMAKE_CXX_COMPILER=$CMAKE_CXX_COMPILER -DCMAKE_PREFIX_PATH=$CMAKE_PREFIX_PATH ../

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,6 +18,7 @@ include(cmake/CPackInfos.cmake)
 
 # Qt Widgets based Gui with OpenGL canvas
 add_subdirectory(openhantek)
+add_subdirectory(firmware EXCLUDE_FROM_ALL)
 
 if (WIN32)
     install(FILES COPYING readme.md DESTINATION ".")

--- a/firmware/CMakeLists.txt
+++ b/firmware/CMakeLists.txt
@@ -1,0 +1,17 @@
+project(FirmwareExtractor C)
+
+find_library( BFD_LIBRARY	NAMES bfd libbdf PATH /usr/lib /usr/lib64 )
+find_path(BFD_INCLUDE bfd.h PATHS /usr/include
+    /usr/local/include
+    /opt/local/include
+    /sw/include)
+
+
+if (NOT BFD_LIBRARY OR NOT BFD_INCLUDE)
+    message(STATUS "BFD not found. Please install binutils-devel (fedora) / binutils-dev (ubuntu)")
+    return()
+endif()
+
+add_executable(${PROJECT_NAME} extractfw.c)
+target_link_libraries(${PROJECT_NAME} ${BFD_LIBRARY} )
+target_include_directories(${PROJECT_NAME} PRIVATE ${BFD_INCLUDE})

--- a/firmware/Makefile
+++ b/firmware/Makefile
@@ -1,7 +1,0 @@
-CFLAGS=-g -O2
-LDLIBS=-lbfd -liberty -lz -ldl
-
-extractfw: extractfw.o
-
-clean:
-	rm -f extractfw extractfw.o

--- a/firmware/fwget.sh
+++ b/firmware/fwget.sh
@@ -2,20 +2,18 @@
 
 shopt -s globstar
 
-cd "$(dirname "$0")"
-make
-rm -rf tmp
-mkdir tmp
+rm -rf build
+mkdir build && cd build && cmake ../ && make && cd ..
 
-cd tmp
+if [ ! -d ./hex ]; then
+mkdir hex && cd hex && \
 for MODEL in "2090" "2150" "2250" "5200" "5200A"; do
     wget http://www.hantek.com/Product/DSO2000/DSO${MODEL}_Driver.zip
     unzip DSO${MODEL}_Driver.zip
-done
+done && \
 cd ..
+fi
 
-for f in tmp/**/*.sys; do
-    ./extractfw $f
+for f in hex/**/*.sys; do
+    ./build/FirmwareExtractor $f && rm $f
 done
-mv tmp/**/*.hex .
-rm -rf tmp

--- a/openhantek/CMakeLists.txt
+++ b/openhantek/CMakeLists.txt
@@ -8,6 +8,10 @@ set(CMAKE_AUTOMOC ON)
 set(CMAKE_AUTOUIC ON)
 set(CMAKE_AUTORCC ON)
 
+if (Qt5Widgets_VERSION VERSION_LESS 5.4.0)
+    message(FATAL_ERROR "Minimum supported Qt5 version is 5.4.0!")
+endif()
+
 # include directories
 set(CMAKE_INCLUDE_CURRENT_DIR ON)
 include_directories(src/ src/hantek src/analyse src/widgets src/docks src/configdialog)

--- a/openhantek/src/analyse/dataanalyzer.cpp
+++ b/openhantek/src/analyse/dataanalyzer.cpp
@@ -1,25 +1,4 @@
-////////////////////////////////////////////////////////////////////////////////
-//
-//  OpenHantek
-//  dataanalyzer.cpp
-//
-//  Copyright (C) 2010  Oliver Haag
-//  oliver.haag@gmail.com
-//
-//  This program is free software: you can redistribute it and/or modify it
-//  under the terms of the GNU General Public License as published by the Free
-//  Software Foundation, either version 3 of the License, or (at your option)
-//  any later version.
-//
-//  This program is distributed in the hope that it will be useful, but WITHOUT
-//  ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
-//  FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
-//  more details.
-//
-//  You should have received a copy of the GNU General Public License along with
-//  this program.  If not, see <http://www.gnu.org/licenses/>.
-//
-////////////////////////////////////////////////////////////////////////////////
+// SPDX-License-Identifier: GPL-2.0+
 
 #define _USE_MATH_DEFINES
 #include <cmath>
@@ -122,6 +101,10 @@ std::unique_ptr<DataAnalyzerResult> DataAnalyzer::convertData(const DSOsamples *
 }
 
 /// \brief Analyzes the data from the dso.
+DataAnalyzer::~DataAnalyzer() {
+    if (window) fftw_free(window);
+}
+
 void DataAnalyzer::applySettings(DsoSettingsScope *scope) { this->scope = scope; }
 
 void DataAnalyzer::setSourceData(const DSOsamples *data) { sourceData = data; }
@@ -131,224 +114,225 @@ std::unique_ptr<DataAnalyzerResult> DataAnalyzer::getNextResult() { return std::
 void DataAnalyzer::samplesAvailable() {
     if (sourceData == nullptr) return;
     std::unique_ptr<DataAnalyzerResult> result = convertData(sourceData, scope);
-    spectrumAnalysis(result.get(), lastWindow, lastRecordLength, scope);
-    lastResult = std::move(result);
+    spectrumAnalysis(result.get(), lastWindow, lastRecordLength, window, scope);
+    lastResult.swap(result);
     emit analyzed();
 }
 
 void DataAnalyzer::spectrumAnalysis(DataAnalyzerResult *result, Dso::WindowFunction &lastWindow,
-                                    unsigned int lastRecordLength, const DsoSettingsScope *scope) {
+                                    unsigned int lastRecordLength, double *&lastWindowBuffer,
+                                    const DsoSettingsScope *scope) {
     // Calculate frequencies, peak-to-peak voltages and spectrums
     for (unsigned int channel = 0; channel < result->channelCount(); ++channel) {
         DataChannel *const channelData = result->modifyData(channel);
 
-        if (!channelData->voltage.sample.empty()) {
-            // Calculate new window
-            unsigned int sampleCount = channelData->voltage.sample.size();
-            if (lastWindow != scope->spectrumWindow || lastRecordLength != sampleCount) {
-                if (lastRecordLength != sampleCount) {
-                    lastRecordLength = sampleCount;
-
-                    if (result->window) fftw_free(result->window);
-                    result->window = (double *)fftw_malloc(sizeof(double) * lastRecordLength);
-                }
-
-                unsigned int windowEnd = lastRecordLength - 1;
-                lastWindow = scope->spectrumWindow;
-
-                switch (scope->spectrumWindow) {
-                case Dso::WINDOW_HAMMING:
-                    for (unsigned int windowPosition = 0; windowPosition < lastRecordLength; ++windowPosition)
-                        *(result->window + windowPosition) = 0.54 - 0.46 * cos(2.0 * M_PI * windowPosition / windowEnd);
-                    break;
-                case Dso::WINDOW_HANN:
-                    for (unsigned int windowPosition = 0; windowPosition < lastRecordLength; ++windowPosition)
-                        *(result->window + windowPosition) = 0.5 * (1.0 - cos(2.0 * M_PI * windowPosition / windowEnd));
-                    break;
-                case Dso::WINDOW_COSINE:
-                    for (unsigned int windowPosition = 0; windowPosition < lastRecordLength; ++windowPosition)
-                        *(result->window + windowPosition) = sin(M_PI * windowPosition / windowEnd);
-                    break;
-                case Dso::WINDOW_LANCZOS:
-                    for (unsigned int windowPosition = 0; windowPosition < lastRecordLength; ++windowPosition) {
-                        double sincParameter = (2.0 * windowPosition / windowEnd - 1.0) * M_PI;
-                        if (sincParameter == 0)
-                            *(result->window + windowPosition) = 1;
-                        else
-                            *(result->window + windowPosition) = sin(sincParameter) / sincParameter;
-                    }
-                    break;
-                case Dso::WINDOW_BARTLETT:
-                    for (unsigned int windowPosition = 0; windowPosition < lastRecordLength; ++windowPosition)
-                        *(result->window + windowPosition) =
-                            2.0 / windowEnd * (windowEnd / 2 - std::abs((double)(windowPosition - windowEnd / 2.0)));
-                    break;
-                case Dso::WINDOW_TRIANGULAR:
-                    for (unsigned int windowPosition = 0; windowPosition < lastRecordLength; ++windowPosition)
-                        *(result->window + windowPosition) =
-                            2.0 / lastRecordLength *
-                            (lastRecordLength / 2 - std::abs((double)(windowPosition - windowEnd / 2.0)));
-                    break;
-                case Dso::WINDOW_GAUSS: {
-                    double sigma = 0.4;
-                    for (unsigned int windowPosition = 0; windowPosition < lastRecordLength; ++windowPosition)
-                        *(result->window + windowPosition) =
-                            exp(-0.5 * pow(((windowPosition - windowEnd / 2) / (sigma * windowEnd / 2)), 2));
-                } break;
-                case Dso::WINDOW_BARTLETTHANN:
-                    for (unsigned int windowPosition = 0; windowPosition < lastRecordLength; ++windowPosition)
-                        *(result->window + windowPosition) =
-                            0.62 - 0.48 * std::abs((double)(windowPosition / windowEnd - 0.5)) -
-                            0.38 * cos(2.0 * M_PI * windowPosition / windowEnd);
-                    break;
-                case Dso::WINDOW_BLACKMAN: {
-                    double alpha = 0.16;
-                    for (unsigned int windowPosition = 0; windowPosition < lastRecordLength; ++windowPosition)
-                        *(result->window + windowPosition) = (1 - alpha) / 2 -
-                                                             0.5 * cos(2.0 * M_PI * windowPosition / windowEnd) +
-                                                             alpha / 2 * cos(4.0 * M_PI * windowPosition / windowEnd);
-                } break;
-                // case WINDOW_KAISER:
-                // TODO WINDOW_KAISER
-                // double alpha = 3.0;
-                // for(unsigned int windowPosition = 0; windowPosition <
-                // lastRecordLength; ++windowPosition)
-                //*(result->window + windowPosition) = ;
-                // break;
-                case Dso::WINDOW_NUTTALL:
-                    for (unsigned int windowPosition = 0; windowPosition < lastRecordLength; ++windowPosition)
-                        *(result->window + windowPosition) = 0.355768 -
-                                                             0.487396 * cos(2 * M_PI * windowPosition / windowEnd) +
-                                                             0.144232 * cos(4 * M_PI * windowPosition / windowEnd) -
-                                                             0.012604 * cos(6 * M_PI * windowPosition / windowEnd);
-                    break;
-                case Dso::WINDOW_BLACKMANHARRIS:
-                    for (unsigned int windowPosition = 0; windowPosition < lastRecordLength; ++windowPosition)
-                        *(result->window + windowPosition) = 0.35875 -
-                                                             0.48829 * cos(2 * M_PI * windowPosition / windowEnd) +
-                                                             0.14128 * cos(4 * M_PI * windowPosition / windowEnd) -
-                                                             0.01168 * cos(6 * M_PI * windowPosition / windowEnd);
-                    break;
-                case Dso::WINDOW_BLACKMANNUTTALL:
-                    for (unsigned int windowPosition = 0; windowPosition < lastRecordLength; ++windowPosition)
-                        *(result->window + windowPosition) = 0.3635819 -
-                                                             0.4891775 * cos(2 * M_PI * windowPosition / windowEnd) +
-                                                             0.1365995 * cos(4 * M_PI * windowPosition / windowEnd) -
-                                                             0.0106411 * cos(6 * M_PI * windowPosition / windowEnd);
-                    break;
-                case Dso::WINDOW_FLATTOP:
-                    for (unsigned int windowPosition = 0; windowPosition < lastRecordLength; ++windowPosition)
-                        *(result->window + windowPosition) = 1.0 - 1.93 * cos(2 * M_PI * windowPosition / windowEnd) +
-                                                             1.29 * cos(4 * M_PI * windowPosition / windowEnd) -
-                                                             0.388 * cos(6 * M_PI * windowPosition / windowEnd) +
-                                                             0.032 * cos(8 * M_PI * windowPosition / windowEnd);
-                    break;
-                default: // Dso::WINDOW_RECTANGULAR
-                    for (unsigned int windowPosition = 0; windowPosition < lastRecordLength; ++windowPosition)
-                        *(result->window + windowPosition) = 1.0;
-                }
-            }
-
-            // Set sampling interval
-            channelData->spectrum.interval = 1.0 / channelData->voltage.interval / sampleCount;
-
-            // Number of real/complex samples
-            unsigned int dftLength = sampleCount / 2;
-
-            // Reallocate memory for samples if the sample count has changed
-            channelData->spectrum.sample.resize(sampleCount);
-
-            // Create sample buffer and apply window
-            double *windowedValues = new double[sampleCount];
-            for (unsigned int position = 0; position < sampleCount; ++position)
-                windowedValues[position] = result->window[position] * channelData->voltage.sample[position];
-
-            // Do discrete real to half-complex transformation
-            /// \todo Check if record length is multiple of 2
-            /// \todo Reuse plan and use FFTW_MEASURE to get fastest algorithm
-            fftw_plan fftPlan = fftw_plan_r2r_1d(sampleCount, windowedValues, &channelData->spectrum.sample.front(),
-                                                 FFTW_R2HC, FFTW_ESTIMATE);
-            fftw_execute(fftPlan);
-            fftw_destroy_plan(fftPlan);
-
-            // Do an autocorrelation to get the frequency of the signal
-            double *conjugateComplex = windowedValues; // Reuse the windowedValues buffer
-
-            // Real values
-            unsigned int position;
-            double correctionFactor = 1.0 / dftLength / dftLength;
-            conjugateComplex[0] =
-                (channelData->spectrum.sample[0] * channelData->spectrum.sample[0]) * correctionFactor;
-            for (position = 1; position < dftLength; ++position)
-                conjugateComplex[position] =
-                    (channelData->spectrum.sample[position] * channelData->spectrum.sample[position] +
-                     channelData->spectrum.sample[sampleCount - position] *
-                         channelData->spectrum.sample[sampleCount - position]) *
-                    correctionFactor;
-            // Complex values, all zero for autocorrelation
-            conjugateComplex[dftLength] =
-                (channelData->spectrum.sample[dftLength] * channelData->spectrum.sample[dftLength]) * correctionFactor;
-            for (++position; position < sampleCount; ++position) conjugateComplex[position] = 0;
-
-            // Do half-complex to real inverse transformation
-            double *correlation = new double[sampleCount];
-            fftPlan = fftw_plan_r2r_1d(sampleCount, conjugateComplex, correlation, FFTW_HC2R, FFTW_ESTIMATE);
-            fftw_execute(fftPlan);
-            fftw_destroy_plan(fftPlan);
-            delete[] conjugateComplex;
-
-            // Calculate peak-to-peak voltage
-            double minimalVoltage, maximalVoltage;
-            minimalVoltage = maximalVoltage = channelData->voltage.sample[0];
-
-            for (unsigned int position = 1; position < sampleCount; ++position) {
-                if (channelData->voltage.sample[position] < minimalVoltage)
-                    minimalVoltage = channelData->voltage.sample[position];
-                else if (channelData->voltage.sample[position] > maximalVoltage)
-                    maximalVoltage = channelData->voltage.sample[position];
-            }
-
-            channelData->amplitude = maximalVoltage - minimalVoltage;
-
-            // Get the frequency from the correlation results
-            double minimumCorrelation = correlation[0];
-            double peakCorrelation = 0;
-            unsigned int peakPosition = 0;
-
-            for (unsigned int position = 1; position < sampleCount / 2; ++position) {
-                if (correlation[position] > peakCorrelation && correlation[position] > minimumCorrelation * 2) {
-                    peakCorrelation = correlation[position];
-                    peakPosition = position;
-                } else if (correlation[position] < minimumCorrelation)
-                    minimumCorrelation = correlation[position];
-            }
-            delete[] correlation;
-
-            // Calculate the frequency in Hz
-            if (peakPosition)
-                channelData->frequency = 1.0 / (channelData->voltage.interval * peakPosition);
-            else
-                channelData->frequency = 0;
-
-            // Finally calculate the real spectrum if we want it
-            if (scope->spectrum[channel].used) {
-                // Convert values into dB (Relative to the reference level)
-                double offset = 60 - scope->spectrumReference - 20 * log10(dftLength);
-                double offsetLimit = scope->spectrumLimit - scope->spectrumReference;
-                for (std::vector<double>::iterator spectrumIterator = channelData->spectrum.sample.begin();
-                     spectrumIterator != channelData->spectrum.sample.end(); ++spectrumIterator) {
-                    double value = 20 * log10(fabs(*spectrumIterator)) + offset;
-
-                    // Check if this value has to be limited
-                    if (offsetLimit > value) value = offsetLimit;
-
-                    *spectrumIterator = value;
-                }
-            }
-        } else if (!channelData->spectrum.sample.empty()) {
+        if (channelData->voltage.sample.empty()) {
             // Clear unused channels
             channelData->spectrum.interval = 0;
             channelData->spectrum.sample.clear();
+            continue;
+        }
+
+        // Calculate new window
+        unsigned int sampleCount = channelData->voltage.sample.size();
+        if (!lastWindowBuffer || lastWindow != scope->spectrumWindow || lastRecordLength != sampleCount) {
+            if (lastWindowBuffer) fftw_free(lastWindowBuffer);
+            lastWindowBuffer = fftw_alloc_real(sampleCount);
+            lastRecordLength = sampleCount;
+
+            unsigned int windowEnd = lastRecordLength - 1;
+            lastWindow = scope->spectrumWindow;
+
+            switch (scope->spectrumWindow) {
+            case Dso::WINDOW_HAMMING:
+                for (unsigned int windowPosition = 0; windowPosition < lastRecordLength; ++windowPosition)
+                    *(lastWindowBuffer + windowPosition) = 0.54 - 0.46 * cos(2.0 * M_PI * windowPosition / windowEnd);
+                break;
+            case Dso::WINDOW_HANN:
+                for (unsigned int windowPosition = 0; windowPosition < lastRecordLength; ++windowPosition)
+                    *(lastWindowBuffer + windowPosition) = 0.5 * (1.0 - cos(2.0 * M_PI * windowPosition / windowEnd));
+                break;
+            case Dso::WINDOW_COSINE:
+                for (unsigned int windowPosition = 0; windowPosition < lastRecordLength; ++windowPosition)
+                    *(lastWindowBuffer + windowPosition) = sin(M_PI * windowPosition / windowEnd);
+                break;
+            case Dso::WINDOW_LANCZOS:
+                for (unsigned int windowPosition = 0; windowPosition < lastRecordLength; ++windowPosition) {
+                    double sincParameter = (2.0 * windowPosition / windowEnd - 1.0) * M_PI;
+                    if (sincParameter == 0)
+                        *(lastWindowBuffer + windowPosition) = 1;
+                    else
+                        *(lastWindowBuffer + windowPosition) = sin(sincParameter) / sincParameter;
+                }
+                break;
+            case Dso::WINDOW_BARTLETT:
+                for (unsigned int windowPosition = 0; windowPosition < lastRecordLength; ++windowPosition)
+                    *(lastWindowBuffer + windowPosition) =
+                        2.0 / windowEnd * (windowEnd / 2 - std::abs((double)(windowPosition - windowEnd / 2.0)));
+                break;
+            case Dso::WINDOW_TRIANGULAR:
+                for (unsigned int windowPosition = 0; windowPosition < lastRecordLength; ++windowPosition)
+                    *(lastWindowBuffer + windowPosition) =
+                        2.0 / lastRecordLength *
+                        (lastRecordLength / 2 - std::abs((double)(windowPosition - windowEnd / 2.0)));
+                break;
+            case Dso::WINDOW_GAUSS: {
+                double sigma = 0.4;
+                for (unsigned int windowPosition = 0; windowPosition < lastRecordLength; ++windowPosition)
+                    *(lastWindowBuffer + windowPosition) =
+                        exp(-0.5 * pow(((windowPosition - windowEnd / 2) / (sigma * windowEnd / 2)), 2));
+            } break;
+            case Dso::WINDOW_BARTLETTHANN:
+                for (unsigned int windowPosition = 0; windowPosition < lastRecordLength; ++windowPosition)
+                    *(lastWindowBuffer + windowPosition) = 0.62 -
+                                                           0.48 * std::abs((double)(windowPosition / windowEnd - 0.5)) -
+                                                           0.38 * cos(2.0 * M_PI * windowPosition / windowEnd);
+                break;
+            case Dso::WINDOW_BLACKMAN: {
+                double alpha = 0.16;
+                for (unsigned int windowPosition = 0; windowPosition < lastRecordLength; ++windowPosition)
+                    *(lastWindowBuffer + windowPosition) = (1 - alpha) / 2 -
+                                                           0.5 * cos(2.0 * M_PI * windowPosition / windowEnd) +
+                                                           alpha / 2 * cos(4.0 * M_PI * windowPosition / windowEnd);
+            } break;
+            // case WINDOW_KAISER:
+            // TODO WINDOW_KAISER
+            // double alpha = 3.0;
+            // for(unsigned int windowPosition = 0; windowPosition <
+            // lastRecordLength; ++windowPosition)
+            //*(window + windowPosition) = ;
+            // break;
+            case Dso::WINDOW_NUTTALL:
+                for (unsigned int windowPosition = 0; windowPosition < lastRecordLength; ++windowPosition)
+                    *(lastWindowBuffer + windowPosition) = 0.355768 -
+                                                           0.487396 * cos(2 * M_PI * windowPosition / windowEnd) +
+                                                           0.144232 * cos(4 * M_PI * windowPosition / windowEnd) -
+                                                           0.012604 * cos(6 * M_PI * windowPosition / windowEnd);
+                break;
+            case Dso::WINDOW_BLACKMANHARRIS:
+                for (unsigned int windowPosition = 0; windowPosition < lastRecordLength; ++windowPosition)
+                    *(lastWindowBuffer + windowPosition) = 0.35875 -
+                                                           0.48829 * cos(2 * M_PI * windowPosition / windowEnd) +
+                                                           0.14128 * cos(4 * M_PI * windowPosition / windowEnd) -
+                                                           0.01168 * cos(6 * M_PI * windowPosition / windowEnd);
+                break;
+            case Dso::WINDOW_BLACKMANNUTTALL:
+                for (unsigned int windowPosition = 0; windowPosition < lastRecordLength; ++windowPosition)
+                    *(lastWindowBuffer + windowPosition) = 0.3635819 -
+                                                           0.4891775 * cos(2 * M_PI * windowPosition / windowEnd) +
+                                                           0.1365995 * cos(4 * M_PI * windowPosition / windowEnd) -
+                                                           0.0106411 * cos(6 * M_PI * windowPosition / windowEnd);
+                break;
+            case Dso::WINDOW_FLATTOP:
+                for (unsigned int windowPosition = 0; windowPosition < lastRecordLength; ++windowPosition)
+                    *(lastWindowBuffer + windowPosition) = 1.0 - 1.93 * cos(2 * M_PI * windowPosition / windowEnd) +
+                                                           1.29 * cos(4 * M_PI * windowPosition / windowEnd) -
+                                                           0.388 * cos(6 * M_PI * windowPosition / windowEnd) +
+                                                           0.032 * cos(8 * M_PI * windowPosition / windowEnd);
+                break;
+            default: // Dso::WINDOW_RECTANGULAR
+                for (unsigned int windowPosition = 0; windowPosition < lastRecordLength; ++windowPosition)
+                    *(lastWindowBuffer + windowPosition) = 1.0;
+            }
+        }
+
+        // Set sampling interval
+        channelData->spectrum.interval = 1.0 / channelData->voltage.interval / sampleCount;
+
+        // Number of real/complex samples
+        unsigned int dftLength = sampleCount / 2;
+
+        // Reallocate memory for samples if the sample count has changed
+        channelData->spectrum.sample.resize(sampleCount);
+
+        // Create sample buffer and apply window
+        std::unique_ptr<double[]> windowedValues = std::unique_ptr<double[]>(new double[sampleCount]);
+
+        for (unsigned int position = 0; position < sampleCount; ++position)
+            windowedValues[position] = lastWindowBuffer[position] * channelData->voltage.sample[position];
+
+        {
+            // Do discrete real to half-complex transformation
+            /// \todo Check if record length is multiple of 2
+            /// \todo Reuse plan and use FFTW_MEASURE to get fastest algorithm
+            fftw_plan fftPlan = fftw_plan_r2r_1d(sampleCount, windowedValues.get(),
+                                                 &channelData->spectrum.sample.front(), FFTW_R2HC, FFTW_ESTIMATE);
+            fftw_execute(fftPlan);
+            fftw_destroy_plan(fftPlan);
+        }
+
+        // Do an autocorrelation to get the frequency of the signal
+        std::unique_ptr<double[]> conjugateComplex = std::move(windowedValues);
+
+        // Real values
+        unsigned int position;
+        double correctionFactor = 1.0 / dftLength / dftLength;
+        conjugateComplex[0] = (channelData->spectrum.sample[0] * channelData->spectrum.sample[0]) * correctionFactor;
+        for (position = 1; position < dftLength; ++position)
+            conjugateComplex[position] =
+                (channelData->spectrum.sample[position] * channelData->spectrum.sample[position] +
+                 channelData->spectrum.sample[sampleCount - position] *
+                     channelData->spectrum.sample[sampleCount - position]) *
+                correctionFactor;
+        // Complex values, all zero for autocorrelation
+        conjugateComplex[dftLength] =
+            (channelData->spectrum.sample[dftLength] * channelData->spectrum.sample[dftLength]) * correctionFactor;
+        for (++position; position < sampleCount; ++position) conjugateComplex[position] = 0;
+
+        // Do half-complex to real inverse transformation
+        std::unique_ptr<double[]> correlation = std::unique_ptr<double[]>(new double[sampleCount]);
+        fftw_plan fftPlan =
+            fftw_plan_r2r_1d(sampleCount, conjugateComplex.get(), correlation.get(), FFTW_HC2R, FFTW_ESTIMATE);
+        fftw_execute(fftPlan);
+        fftw_destroy_plan(fftPlan);
+
+        // Calculate peak-to-peak voltage
+        double minimalVoltage, maximalVoltage;
+        minimalVoltage = maximalVoltage = channelData->voltage.sample[0];
+
+        for (unsigned int position = 1; position < sampleCount; ++position) {
+            if (channelData->voltage.sample[position] < minimalVoltage)
+                minimalVoltage = channelData->voltage.sample[position];
+            else if (channelData->voltage.sample[position] > maximalVoltage)
+                maximalVoltage = channelData->voltage.sample[position];
+        }
+
+        channelData->amplitude = maximalVoltage - minimalVoltage;
+
+        // Get the frequency from the correlation results
+        double minimumCorrelation = correlation[0];
+        double peakCorrelation = 0;
+        unsigned int peakPosition = 0;
+
+        for (unsigned int position = 1; position < sampleCount / 2; ++position) {
+            if (correlation[position] > peakCorrelation && correlation[position] > minimumCorrelation * 2) {
+                peakCorrelation = correlation[position];
+                peakPosition = position;
+            } else if (correlation[position] < minimumCorrelation)
+                minimumCorrelation = correlation[position];
+        }
+        correlation.reset(nullptr);
+
+        // Calculate the frequency in Hz
+        if (peakPosition)
+            channelData->frequency = 1.0 / (channelData->voltage.interval * peakPosition);
+        else
+            channelData->frequency = 0;
+
+        // Finally calculate the real spectrum if we want it
+        if (scope->spectrum[channel].used) {
+            // Convert values into dB (Relative to the reference level)
+            double offset = 60 - scope->spectrumReference - 20 * log10(dftLength);
+            double offsetLimit = scope->spectrumLimit - scope->spectrumReference;
+            for (std::vector<double>::iterator spectrumIterator = channelData->spectrum.sample.begin();
+                 spectrumIterator != channelData->spectrum.sample.end(); ++spectrumIterator) {
+                double value = 20 * log10(fabs(*spectrumIterator)) + offset;
+
+                // Check if this value has to be limited
+                if (offsetLimit > value) value = offsetLimit;
+
+                *spectrumIterator = value;
+            }
         }
     }
 }

--- a/openhantek/src/analyse/dataanalyzer.h
+++ b/openhantek/src/analyse/dataanalyzer.h
@@ -24,6 +24,7 @@ class DataAnalyzer : public QObject {
     Q_OBJECT
 
   public:
+    ~DataAnalyzer();
     void applySettings(DsoSettingsScope *scope);
     void setSourceData(const DSOsamples *data);
     std::unique_ptr<DataAnalyzerResult> getNextResult();
@@ -35,12 +36,14 @@ class DataAnalyzer : public QObject {
   private:
     static std::unique_ptr<DataAnalyzerResult> convertData(const DSOsamples *data, const DsoSettingsScope *scope);
     static void spectrumAnalysis(DataAnalyzerResult *result, Dso::WindowFunction &lastWindow,
-                                 unsigned int lastRecordLength, const DsoSettingsScope *scope);
+                                 unsigned int lastRecordLength, double *&lastWindowBuffer,
+                                 const DsoSettingsScope *scope);
 
   private:
     DsoSettingsScope *scope;
     unsigned int lastRecordLength = 0;                        ///< The record length of the previously analyzed data
     Dso::WindowFunction lastWindow = (Dso::WindowFunction)-1; ///< The previously used dft window function
+    double *window = nullptr;
     const DSOsamples *sourceData = nullptr;
     std::unique_ptr<DataAnalyzerResult> lastResult;
   signals:

--- a/openhantek/src/analyse/dataanalyzerresult.cpp
+++ b/openhantek/src/analyse/dataanalyzerresult.cpp
@@ -1,4 +1,7 @@
+// SPDX-License-Identifier: GPL-2.0+
+
 #include "dataanalyzerresult.h"
+#include <QDebug>
 #include <stdexcept>
 
 DataAnalyzerResult::DataAnalyzerResult(unsigned int channelCount) { analyzedData.resize(channelCount); }

--- a/openhantek/src/analyse/dataanalyzerresult.h
+++ b/openhantek/src/analyse/dataanalyzerresult.h
@@ -29,7 +29,6 @@ class DataAnalyzerResult {
     DataChannel *modifyData(int channel);
     unsigned int sampleCount() const;
     unsigned int channelCount() const;
-    double *window = nullptr; ///< The array for the dft window factors
 
     /**
      * Applies a new maximum samples value, if the given value is higher than the

--- a/openhantek/src/docks/HorizontalDock.h
+++ b/openhantek/src/docks/HorizontalDock.h
@@ -53,10 +53,8 @@ class HorizontalDock : public QDockWidget {
 
     QStringList formatStrings; ///< Strings for the formats
 
-    bool suppressSignals; ///< Disable changed-signals temporarily
-
   public slots:
-    void availableRecordLengthsChanged(const QList<unsigned int> &recordLengths);
+    void availableRecordLengthsChanged(const std::vector<unsigned> &recordLengths);
     void samplerateLimitsChanged(double minimum, double maximum);
     void samplerateSet(int mode, QList<double> sampleSteps);
 

--- a/openhantek/src/hantek/definitions.h
+++ b/openhantek/src/hantek/definitions.h
@@ -19,7 +19,7 @@
 namespace Dso {
 /// \enum ErrorCode                                           hantek/control.h
 /// \brief The return codes for device control methods.
-enum ErrorCode {
+enum class ErrorCode {
     ERROR_NONE = 0,         ///< Successful operation
     ERROR_CONNECTION = -1,  ///< Device not connected or communication error
     ERROR_UNSUPPORTED = -2, ///< Not supported by this device
@@ -821,7 +821,8 @@ enum CaptureState {
     CAPTURE_SAMPLING = 1,  ///< The scope is sampling data after triggering
     CAPTURE_READY = 2,     ///< Sampling data is available (DSO-2090/DSO-2150)
     CAPTURE_READY2250 = 3, ///< Sampling data is available (DSO-2250)
-    CAPTURE_READY5200 = 7  ///< Sampling data is available (DSO-5200/DSO-5200A)
+    CAPTURE_READY5200 = 7, ///< Sampling data is available (DSO-5200/DSO-5200A)
+    CAPTURE_ERROR = 1000
 };
 
 //////////////////////////////////////////////////////////////////////////////

--- a/openhantek/src/hantek/hantekdsocontrol.cpp
+++ b/openhantek/src/hantek/hantekdsocontrol.cpp
@@ -32,9 +32,7 @@ void HantekDsoControl::startSampling() {
     if (specification.isSoftwareTriggerDevice) {
         // Convert to GUI presentable values (1e5 -> 1.0, 48e6 -> 480.0 etc)
         QList<double> sampleSteps;
-        for (double v: specification.sampleSteps) {
-            sampleSteps << v/1e5;
-        }
+        for (double v : specification.sampleSteps) { sampleSteps << v / 1e5; }
         emit samplerateSet(1, sampleSteps);
     }
 
@@ -47,15 +45,12 @@ void HantekDsoControl::stopSampling() {
     emit samplingStopped();
 }
 
-/// \brief Get a list of the names of the special trigger sources.
 const QStringList *HantekDsoControl::getSpecialTriggerSources() { return &(specialTriggerSources); }
 
 const USBDevice *HantekDsoControl::getDevice() const { return device; }
 
 const DSOsamples &HantekDsoControl::getLastSamples() { return result; }
 
-/// \brief Initializes the command buffers and lists.
-/// \param parent The parent widget.
 HantekDsoControl::HantekDsoControl(USBDevice *device) : device(device) {
     if (device == nullptr) throw new std::runtime_error("No usb device for HantekDsoControl");
 
@@ -73,10 +68,8 @@ HantekDsoControl::HantekDsoControl(USBDevice *device) : device(device) {
 
     specification.samplerate.single.base = 50e6;
     specification.samplerate.single.max = 50e6;
-    specification.samplerate.single.recordLengths << 0;
     specification.samplerate.multi.base = 100e6;
     specification.samplerate.multi.max = 100e6;
-    specification.samplerate.multi.recordLengths << 0;
 
     for (unsigned channel = 0; channel < HANTEK_CHANNELS; ++channel) {
         for (unsigned gainId = 0; gainId < 9; ++gainId) {
@@ -102,8 +95,8 @@ HantekDsoControl::HantekDsoControl(USBDevice *device) : device(device) {
         controlsettings.voltage[channel].offsetReal = 0.0;
         controlsettings.voltage[channel].used = false;
     }
-    controlsettings.recordLengthId = 1;
     controlsettings.usedChannels = 0;
+    controlsettings.recordLengthId = 1;
 
     // Transmission-ready control commands
     this->control[CONTROLINDEX_SETOFFSET] = new ControlSetOffset();
@@ -112,9 +105,6 @@ HantekDsoControl::HantekDsoControl(USBDevice *device) : device(device) {
     this->controlCode[CONTROLINDEX_SETRELAYS] = CONTROL_SETRELAYS;
 
     for (int cIndex = 0; cIndex < CONTROLINDEX_COUNT; ++cIndex) this->controlPending[cIndex] = false;
-
-    // Sample buffers
-    result.data.resize(HANTEK_CHANNELS);
 
     int errorCode;
 
@@ -153,11 +143,11 @@ HantekDsoControl::HantekDsoControl(USBDevice *device) : device(device) {
         specification.samplerate.single.base = 50e6;
         specification.samplerate.single.max = 75e6;
         specification.samplerate.single.maxDownsampler = 131072;
-        specification.samplerate.single.recordLengths << UINT_MAX << 10240 << 32768;
+        specification.samplerate.single.recordLengths = {UINT_MAX, 10240, 32768};
         specification.samplerate.multi.base = 100e6;
         specification.samplerate.multi.max = 150e6;
         specification.samplerate.multi.maxDownsampler = 131072;
-        specification.samplerate.multi.recordLengths << UINT_MAX << 20480 << 65536;
+        specification.samplerate.multi.recordLengths = {UINT_MAX, 20480, 65536};
         specification.bufferDividers << 1000 << 1 << 1;
         specification.gainSteps << 0.08 << 0.16 << 0.40 << 0.80 << 1.60 << 4.00 << 8.0 << 16.0 << 40.0;
         for (int channel = 0; channel < HANTEK_CHANNELS; ++channel)
@@ -179,11 +169,11 @@ HantekDsoControl::HantekDsoControl(USBDevice *device) : device(device) {
         specification.samplerate.single.base = 50e6;
         specification.samplerate.single.max = 50e6;
         specification.samplerate.single.maxDownsampler = 131072;
-        specification.samplerate.single.recordLengths << UINT_MAX << 10240 << 32768;
+        specification.samplerate.single.recordLengths = {UINT_MAX, 10240, 32768};
         specification.samplerate.multi.base = 100e6;
         specification.samplerate.multi.max = 100e6;
         specification.samplerate.multi.maxDownsampler = 131072;
-        specification.samplerate.multi.recordLengths << UINT_MAX << 20480 << 65536;
+        specification.samplerate.multi.recordLengths = {UINT_MAX, 20480, 65536};
         specification.bufferDividers << 1000 << 1 << 1;
         specification.gainSteps << 0.08 << 0.16 << 0.40 << 0.80 << 1.60 << 4.00 << 8.0 << 16.0 << 40.0;
         for (int channel = 0; channel < HANTEK_CHANNELS; ++channel)
@@ -216,11 +206,11 @@ HantekDsoControl::HantekDsoControl(USBDevice *device) : device(device) {
         specification.samplerate.single.base = 100e6;
         specification.samplerate.single.max = 100e6;
         specification.samplerate.single.maxDownsampler = 65536;
-        specification.samplerate.single.recordLengths << UINT_MAX << 10240 << 524288;
+        specification.samplerate.single.recordLengths = {UINT_MAX, 10240, 524288};
         specification.samplerate.multi.base = 200e6;
         specification.samplerate.multi.max = 250e6;
         specification.samplerate.multi.maxDownsampler = 65536;
-        specification.samplerate.multi.recordLengths << UINT_MAX << 20480 << 1048576;
+        specification.samplerate.multi.recordLengths = {UINT_MAX, 20480, 1048576};
         specification.bufferDividers << 1000 << 1 << 1;
         specification.gainSteps << 0.08 << 0.16 << 0.40 << 0.80 << 1.60 << 4.00 << 8.0 << 16.0 << 40.0;
         for (int channel = 0; channel < HANTEK_CHANNELS; ++channel)
@@ -251,11 +241,11 @@ HantekDsoControl::HantekDsoControl(USBDevice *device) : device(device) {
         specification.samplerate.single.base = 100e6;
         specification.samplerate.single.max = 125e6;
         specification.samplerate.single.maxDownsampler = 131072;
-        specification.samplerate.single.recordLengths << UINT_MAX << 10240 << 14336;
+        specification.samplerate.single.recordLengths = {UINT_MAX, 10240, 14336};
         specification.samplerate.multi.base = 200e6;
         specification.samplerate.multi.max = 250e6;
         specification.samplerate.multi.maxDownsampler = 131072;
-        specification.samplerate.multi.recordLengths << UINT_MAX << 20480 << 28672;
+        specification.samplerate.multi.recordLengths = {UINT_MAX, 20480, 28672};
         specification.bufferDividers << 1000 << 1 << 1;
         specification.gainSteps << 0.16 << 0.40 << 0.80 << 1.60 << 4.00 << 8.0 << 16.0 << 40.0 << 80.0;
         /// \todo Use calibration data to get the DSO-5200(A) sample ranges
@@ -297,11 +287,11 @@ HantekDsoControl::HantekDsoControl(USBDevice *device) : device(device) {
         specification.samplerate.single.base = 1e6;
         specification.samplerate.single.max = 48e6;
         specification.samplerate.single.maxDownsampler = 10;
-        specification.samplerate.single.recordLengths << UINT_MAX << 10240;
+        specification.samplerate.single.recordLengths = {UINT_MAX, 10240};
         specification.samplerate.multi.base = 1e6;
         specification.samplerate.multi.max = 48e6;
         specification.samplerate.multi.maxDownsampler = 10;
-        specification.samplerate.multi.recordLengths << UINT_MAX << 20480;
+        specification.samplerate.multi.recordLengths = {UINT_MAX, 20480};
         specification.bufferDividers << 1000 << 1 << 1;
         specification.gainSteps << 0.08 << 0.16 << 0.40 << 0.80 << 1.60 << 4.00 << 8.0 << 16.0 << 40.0;
         // This data was based on testing and depends on Divider.
@@ -318,45 +308,36 @@ HantekDsoControl::HantekDsoControl(USBDevice *device) : device(device) {
         throw new std::runtime_error("unknown model");
     }
 
-    controlsettings.recordLengthId = 1;
-    controlsettings.samplerate.limits = &(specification.samplerate.single);
-    controlsettings.samplerate.downsampler = 1;
     this->previousSampleCount = 0;
 
     // Get channel level data
     errorCode = device->controlRead(CONTROL_VALUE, (unsigned char *)&(specification.offsetLimit),
                                     sizeof(specification.offsetLimit), (int)VALUE_OFFSETLIMITS);
     if (errorCode < 0) {
-        device->disconnect();
+        qWarning() << tr("Couldn't get channel level data from oscilloscope");
         emit statusMessage(tr("Couldn't get channel level data from oscilloscope"), 0);
+        emit communicationError();
         return;
     }
 
     sampling = false;
 }
 
-/// \brief Disconnects the device.
 HantekDsoControl::~HantekDsoControl() {
     // Clean up commands
     for (int cIndex = 0; cIndex < BULK_COUNT; ++cIndex) { delete command[cIndex]; }
 }
 
-/// \brief Gets the physical channel count for this oscilloscope.
-/// \return The number of physical channels.
 unsigned HantekDsoControl::getChannelCount() { return HANTEK_CHANNELS; }
 
-/// \brief Get available record lengths for this oscilloscope.
-/// \return The number of physical channels, empty list for continuous.
-QList<unsigned> *HantekDsoControl::getAvailableRecordLengths() { return &controlsettings.samplerate.limits->recordLengths; }
+const std::vector<unsigned> &HantekDsoControl::getAvailableRecordLengths() { //
+    return controlsettings.samplerate.limits->recordLengths;
+}
 
-/// \brief Get minimum samplerate for this oscilloscope.
-/// \return The minimum samplerate for the current configuration in S/s.
 double HantekDsoControl::getMinSamplerate() {
     return (double)specification.samplerate.single.base / specification.samplerate.single.maxDownsampler;
 }
 
-/// \brief Get maximum samplerate for this oscilloscope.
-/// \return The maximum samplerate for the current configuration in S/s.
 double HantekDsoControl::getMaxSamplerate() {
     ControlSamplerateLimits *limits =
         (controlsettings.usedChannels <= 1) ? &specification.samplerate.multi : &specification.samplerate.single;
@@ -368,8 +349,7 @@ void HantekDsoControl::updateInterval() {
     // Check the current oscilloscope state everytime 25% of the time the buffer
     // should be refilled
     if (isRollMode())
-        cycleTime = (int)((double)device->getPacketSize() /
-                          ((controlsettings.samplerate.limits == &specification.samplerate.multi) ? 1 : HANTEK_CHANNELS) /
+        cycleTime = (int)((double)device->getPacketSize() / (isFastRate() ? 1 : HANTEK_CHANNELS) /
                           controlsettings.samplerate.current * 250);
     else
         cycleTime = (int)((double)getRecordLength() / controlsettings.samplerate.current * 250);
@@ -378,15 +358,18 @@ void HantekDsoControl::updateInterval() {
     cycleTime = qBound(10, cycleTime, 1000);
 }
 
-bool HantekDsoControl::isRollMode() {
+bool HantekDsoControl::isRollMode() const {
     return controlsettings.samplerate.limits->recordLengths[controlsettings.recordLengthId] == UINT_MAX;
 }
 
-int HantekDsoControl::getRecordLength() { return controlsettings.samplerate.limits->recordLengths[controlsettings.recordLengthId]; }
+bool HantekDsoControl::isFastRate() const {
+    return controlsettings.samplerate.limits == &specification.samplerate.multi;
+}
 
-/// \brief Calculates the trigger point from the CommandGetCaptureState data.
-/// \param value The data value that contains the trigger point.
-/// \return The calculated trigger point for the given data.
+int HantekDsoControl::getRecordLength() const {
+    return controlsettings.samplerate.limits->recordLengths[controlsettings.recordLengthId];
+}
+
 unsigned HantekDsoControl::calculateTriggerPoint(unsigned value) {
     unsigned result = value;
 
@@ -397,235 +380,192 @@ unsigned HantekDsoControl::calculateTriggerPoint(unsigned value) {
     return result;
 }
 
-/// \brief Gets the current state.
-/// \return The current CaptureState of the oscilloscope, libusb error code on
-/// error.
-int HantekDsoControl::getCaptureState() {
+std::pair<int, unsigned> HantekDsoControl::getCaptureState() const {
     int errorCode;
 
-    if (!specification.supportsCaptureState) return CAPTURE_READY;
+    if (!specification.supportsCaptureState) return std::make_pair(CAPTURE_READY, 0);
 
     errorCode = device->bulkCommand(command[BULK_GETCAPTURESTATE], 1);
-    if (errorCode < 0) return errorCode;
+    if (errorCode < 0) {
+        qWarning() << "Getting capture state failed: " << libUsbErrorString(errorCode);
+        return std::make_pair(CAPTURE_ERROR, 0);
+    }
 
     BulkResponseGetCaptureState response;
     errorCode = device->bulkRead(response.data(), response.getSize());
-    if (errorCode < 0) return errorCode;
-
-    controlsettings.trigger.point = this->calculateTriggerPoint(response.getTriggerPoint());
-
-    return (int)response.getCaptureState();
-}
-
-/// \brief Gets sample data from the oscilloscope and converts it.
-/// \return sample count on success, libusb error code on error.
-/// TODO Refactor. MODEL_DSO6022BE needs to be handled differently most of the time
-int HantekDsoControl::getSamples(bool process) {
-    int errorCode;
-
-    const unsigned DROP_DSO6022_HEAD = 0x410;
-    const unsigned DROP_DSO6022_TAIL = 0x3F0;
-
-    if (device->getUniqueModelID() != MODEL_DSO6022BE) {
-        // Request data
-        errorCode = device->bulkCommand(command[BULK_GETDATA], 1);
-        if (errorCode < 0) return errorCode;
+    if (errorCode < 0) {
+        qWarning() << "Getting capture state failed: " << libUsbErrorString(errorCode);
+        return std::make_pair(CAPTURE_ERROR, 0);
     }
 
-    // Save raw data to temporary buffer
-    bool fastRate = false;
-    unsigned totalSampleCount = this->getSampleCount(&fastRate);
-    if (totalSampleCount == UINT_MAX) return LIBUSB_ERROR_INVALID_PARAM;
+    return std::make_pair((int)response.getCaptureState(), response.getTriggerPoint());
+}
+
+std::vector<unsigned char> HantekDsoControl::getSamples(unsigned &previousSampleCount) const {
+    if (!specification.useControlNoBulk) {
+        // Request data
+        int errorCode = device->bulkCommand(command[BULK_GETDATA], 1);
+        if (errorCode < 0) {
+            qWarning() << "Getting sample data failed: " << libUsbErrorString(errorCode);
+            emit communicationError();
+            return std::vector<unsigned char>();
+        }
+    }
+
+    unsigned totalSampleCount = this->getSampleCount();
 
     // To make sure no samples will remain in the scope buffer, also check the
     // sample count before the last sampling started
-    if (totalSampleCount < this->previousSampleCount) {
-        unsigned currentSampleCount = totalSampleCount;
-        totalSampleCount = this->previousSampleCount;
-        this->previousSampleCount = currentSampleCount; // Using sampleCount as temporary buffer since it
-                                                        // was set to totalSampleCount
+    if (totalSampleCount < previousSampleCount) {
+        std::swap(totalSampleCount, previousSampleCount);
     } else {
-        this->previousSampleCount = totalSampleCount;
+        previousSampleCount = totalSampleCount;
     }
 
-    unsigned sampleCount = totalSampleCount;
-    if (!fastRate) sampleCount /= HANTEK_CHANNELS;
-    unsigned dataLength = totalSampleCount;
-    if (specification.sampleSize > 8) dataLength *= 2;
+    unsigned dataLength = (specification.sampleSize > 8) ? totalSampleCount * 2 : totalSampleCount;
 
+    // Save raw data to temporary buffer
     std::vector<unsigned char> data(dataLength);
-    errorCode = device->bulkReadMulti(data.data(), dataLength);
-    if (errorCode < 0) return errorCode;
-
-    // Process the data only if we want it
-    if (!process) return LIBUSB_SUCCESS;
-
-    // How much data did we really receive?
-    dataLength = errorCode;
-    if (specification.sampleSize > 8)
-        totalSampleCount = dataLength / 2;
-    else
-        totalSampleCount = dataLength;
-
-    // Convert channel data
-    if (fastRate) {
-        QWriteLocker locker(&result.lock);
-        result.samplerate = controlsettings.samplerate.current;
-        result.append = isRollMode();
-
-        // Fast rate mode, one channel is using all buffers
-        sampleCount = totalSampleCount;
-        int channel = 0;
-        for (; channel < HANTEK_CHANNELS; ++channel) {
-            if (controlsettings.voltage[channel].used) break;
-        }
-
-        // Clear unused channels
-        for (int channelCounter = 0; channelCounter < HANTEK_CHANNELS; ++channelCounter)
-            if (channelCounter != channel) { result.data[channelCounter].clear(); }
-
-        if (channel < HANTEK_CHANNELS) {
-            // Resize sample vector
-            result.data[channel].resize(sampleCount);
-
-            // Convert data from the oscilloscope and write it into the sample
-            // buffer
-            unsigned bufferPosition = controlsettings.trigger.point * 2;
-            if (specification.sampleSize > 8) {
-                // Additional most significant bits after the normal data
-                unsigned extraBitsPosition; // Track the position of the extra
-                // bits in the additional byte
-                unsigned extraBitsSize = specification.sampleSize - 8;                 // Number of extra bits
-                unsigned short int extraBitsMask = (0x00ff << extraBitsSize) & 0xff00; // Mask for extra bits extraction
-
-                for (unsigned realPosition = 0; realPosition < sampleCount; ++realPosition, ++bufferPosition) {
-                    if (bufferPosition >= sampleCount) bufferPosition %= sampleCount;
-
-                    extraBitsPosition = bufferPosition % HANTEK_CHANNELS;
-
-                    result.data[channel][realPosition] =
-                        ((double)((unsigned short int)data[bufferPosition] +
-                                  (((unsigned short int)data[sampleCount + bufferPosition - extraBitsPosition]
-                                    << (8 - (HANTEK_CHANNELS - 1 - extraBitsPosition) * extraBitsSize)) &
-                                   extraBitsMask)) /
-                             specification.voltageLimit[channel][controlsettings.voltage[channel].gain] -
-                         controlsettings.voltage[channel].offsetReal) *
-                        specification.gainSteps[controlsettings.voltage[channel].gain];
-                }
-            } else {
-                for (unsigned realPosition = 0; realPosition < sampleCount; ++realPosition, ++bufferPosition) {
-                    if (bufferPosition >= sampleCount) bufferPosition %= sampleCount;
-
-                    double dataBuf = (double)((int)data[bufferPosition]);
-                    result.data[channel][realPosition] =
-                        (dataBuf / specification.voltageLimit[channel][controlsettings.voltage[channel].gain] -
-                         controlsettings.voltage[channel].offsetReal) *
-                        specification.gainSteps[controlsettings.voltage[channel].gain];
-                }
-            }
-        }
-    } else {
-        QWriteLocker locker(&result.lock);
-        result.samplerate = controlsettings.samplerate.current;
-        result.append = isRollMode();
-
-        // Normal mode, channels are using their separate buffers
-        sampleCount = totalSampleCount / HANTEK_CHANNELS;
-        // if device is 6022BE, drop heading & trailing samples
-        if (device->getUniqueModelID() == MODEL_DSO6022BE) sampleCount -= (DROP_DSO6022_HEAD + DROP_DSO6022_TAIL);
-        for (int channel = 0; channel < HANTEK_CHANNELS; ++channel) {
-            if (controlsettings.voltage[channel].used) {
-                // Resize sample vector
-                if (result.data[channel].size() < sampleCount) { result.data[channel].resize(sampleCount); }
-
-                // Convert data from the oscilloscope and write it into the sample
-                // buffer
-                unsigned bufferPosition = controlsettings.trigger.point * 2;
-                if (specification.sampleSize > 8) {
-                    // Additional most significant bits after the normal data
-                    unsigned extraBitsSize = specification.sampleSize - 8; // Number of extra bits
-                    unsigned short int extraBitsMask =
-                        (0x00ff << extraBitsSize) & 0xff00;    // Mask for extra bits extraction
-                    unsigned extraBitsIndex = 8 - channel * 2; // Bit position offset for extra bits extraction
-
-                    for (unsigned realPosition = 0; realPosition < sampleCount;
-                         ++realPosition, bufferPosition += HANTEK_CHANNELS) {
-                        if (bufferPosition >= totalSampleCount) bufferPosition %= totalSampleCount;
-
-                        result.data[channel][realPosition] =
-                            ((double)((unsigned short int)data[bufferPosition + HANTEK_CHANNELS - 1 - channel] +
-                                      (((unsigned short int)data[totalSampleCount + bufferPosition] << extraBitsIndex) &
-                                       extraBitsMask)) /
-                                 specification.voltageLimit[channel][controlsettings.voltage[channel].gain] -
-                             controlsettings.voltage[channel].offsetReal) *
-                            specification.gainSteps[controlsettings.voltage[channel].gain];
-                    }
-                } else {
-                    if (device->getUniqueModelID() == MODEL_DSO6022BE) {
-                        bufferPosition += channel;
-                        // if device is 6022BE, offset DROP_DSO6022_HEAD incrementally
-                        bufferPosition += DROP_DSO6022_HEAD * 2;
-                    } else
-                        bufferPosition += HANTEK_CHANNELS - 1 - channel;
-
-                    for (unsigned realPosition = 0; realPosition < sampleCount;
-                         ++realPosition, bufferPosition += HANTEK_CHANNELS) {
-                        if (bufferPosition >= totalSampleCount) bufferPosition %= totalSampleCount;
-
-                        if (device->getUniqueModelID() == MODEL_DSO6022BE) {
-                            double dataBuf = (double)((int)(data[bufferPosition] - 0x83));
-                            result.data[channel][realPosition] =
-                                (dataBuf / specification.voltageLimit[channel][controlsettings.voltage[channel].gain]) *
-                                specification.gainSteps[controlsettings.voltage[channel].gain];
-                        } else {
-                            double dataBuf = (double)((int)(data[bufferPosition]));
-                            result.data[channel][realPosition] =
-                                (dataBuf / specification.voltageLimit[channel][controlsettings.voltage[channel].gain] -
-                                 controlsettings.voltage[channel].offsetReal) *
-                                specification.gainSteps[controlsettings.voltage[channel].gain];
-                        }
-                    }
-                }
-            } else {
-                // Clear unused channels
-                result.data[channel].clear();
-            }
-        }
+    int errorcode = device->bulkReadMulti(data.data(), dataLength);
+    if (errorcode < 0) {
+        qWarning() << "Getting sample data failed: " << libUsbErrorString(errorcode);
+        return std::vector<unsigned char>();
     }
+    data.resize((size_t)errorcode);
 
     static unsigned id = 0;
     ++id;
     timestampDebug(QString("Received packet %1").arg(id));
 
-    emit samplesAvailable();
-
-    return errorCode;
+    return data;
 }
 
-/// \brief Calculated the nearest samplerate supported by the oscilloscope.
-/// \param samplerate The target samplerate, that should be met as good as
-/// possible.
-/// \param fastRate true, if the fast rate mode is enabled.
-/// \param maximum The target samplerate is the maximum allowed when true, the
-/// minimum otherwise.
-/// \param downsampler Pointer to where the selected downsampling factor should
-/// be written.
-/// \return The nearest samplerate supported, 0.0 on error.
-double HantekDsoControl::getBestSamplerate(double samplerate, bool fastRate, bool maximum, unsigned *downsampler) {
+void HantekDsoControl::convertRawDataToSamples(const std::vector<unsigned char> &rawData) {
+    const size_t totalSampleCount = (specification.sampleSize > 8) ? rawData.size() / 2 : rawData.size();
+
+    QWriteLocker locker(&result.lock);
+    result.samplerate = controlsettings.samplerate.current;
+    result.append = isRollMode();
+    // Prepare result buffers
+    result.data.resize(HANTEK_CHANNELS);
+    for (int channelCounter = 0; channelCounter < HANTEK_CHANNELS; ++channelCounter)
+        result.data[channelCounter].clear();
+
+    const unsigned extraBitsSize = specification.sampleSize - 8;             // Number of extra bits
+    const unsigned short extraBitsMask = (0x00ff << extraBitsSize) & 0xff00; // Mask for extra bits extraction
+
+    // Convert channel data
+    if (isFastRate()) {
+        // Fast rate mode, one channel is using all buffers
+        unsigned channel = 0;
+        for (; channel < HANTEK_CHANNELS; ++channel) {
+            if (controlsettings.voltage[channel].used) break;
+        }
+
+        if (channel >= HANTEK_CHANNELS) return;
+
+        // Resize sample vector
+        result.data[channel].resize(totalSampleCount);
+
+        const int gainID = (int)controlsettings.voltage[channel].gain;
+        const unsigned short limit = specification.voltageLimit[channel][gainID];
+        const double offset = controlsettings.voltage[channel].offsetReal;
+        const double gainStep = specification.gainSteps[gainID];
+
+        // Convert data from the oscilloscope and write it into the sample buffer
+        unsigned bufferPosition = controlsettings.trigger.point * 2;
+        if (specification.sampleSize > 8) {
+            for (unsigned pos = 0; pos < totalSampleCount; ++pos, ++bufferPosition) {
+                if (bufferPosition >= totalSampleCount) bufferPosition %= totalSampleCount;
+
+                const unsigned short low = rawData[bufferPosition];
+                const unsigned extraBitsPosition = bufferPosition % HANTEK_CHANNELS;
+                const unsigned shift = (8 - (HANTEK_CHANNELS - 1 - extraBitsPosition) * extraBitsSize);
+                const unsigned short high =
+                    ((unsigned short int)rawData[totalSampleCount + bufferPosition - extraBitsPosition] << shift) &
+                    extraBitsMask;
+
+                result.data[channel][pos] = ((double)(low + high) / limit - offset) * gainStep;
+            }
+        } else {
+            for (unsigned pos = 0; pos < totalSampleCount; ++pos, ++bufferPosition) {
+                if (bufferPosition >= totalSampleCount) bufferPosition %= totalSampleCount;
+
+                double dataBuf = (double)((int)rawData[bufferPosition]);
+                result.data[channel][pos] = (dataBuf / limit - offset) * gainStep;
+            }
+        }
+    } else {
+        // Normal mode, channels are using their separate buffers
+        for (unsigned channel = 0; channel < HANTEK_CHANNELS; ++channel) {
+            result.data[channel].resize(totalSampleCount / HANTEK_CHANNELS);
+
+            const int gainID = controlsettings.voltage[channel].gain;
+            const unsigned short limit = specification.voltageLimit[channel][gainID];
+            const double offset = controlsettings.voltage[channel].offsetReal;
+            const double gainStep = specification.gainSteps[gainID];
+
+            // Convert data from the oscilloscope and write it into the sample buffer
+            unsigned bufferPosition = controlsettings.trigger.point * 2;
+            if (specification.sampleSize > 8) {
+                // Additional most significant bits after the normal data
+                unsigned extraBitsIndex = 8 - channel * 2; // Bit position offset for extra bits extraction
+
+                for (unsigned realPosition = 0; realPosition < result.data[channel].size();
+                     ++realPosition, bufferPosition += HANTEK_CHANNELS) {
+                    if (bufferPosition >= totalSampleCount) bufferPosition %= totalSampleCount;
+
+                    const unsigned short low = rawData[bufferPosition + HANTEK_CHANNELS - 1 - channel];
+                    const unsigned short high =
+                        ((unsigned short int)rawData[totalSampleCount + bufferPosition] << extraBitsIndex) &
+                        extraBitsMask;
+
+                    result.data[channel][realPosition] = ((double)(low + high) / limit - offset) * gainStep;
+                }
+            } else if (device->getUniqueModelID() == MODEL_DSO6022BE) {
+                // if device is 6022BE, drop heading & trailing samples
+                const unsigned DROP_DSO6022_HEAD = 0x410;
+                const unsigned DROP_DSO6022_TAIL = 0x3F0;
+                if (!isRollMode()) {
+                    result.data[channel].resize(result.data[channel].size() - (DROP_DSO6022_HEAD + DROP_DSO6022_TAIL));
+                    // if device is 6022BE, offset DROP_DSO6022_HEAD incrementally
+                    bufferPosition += DROP_DSO6022_HEAD * 2;
+                }
+                bufferPosition += channel;
+                for (unsigned pos = 0; pos < result.data[channel].size(); ++pos, bufferPosition += HANTEK_CHANNELS) {
+                    if (bufferPosition >= totalSampleCount) bufferPosition %= totalSampleCount;
+                    double dataBuf = (double)((int)(rawData[bufferPosition] - 0x83));
+                    result.data[channel][pos] = (dataBuf / limit) * gainStep;
+                }
+            } else {
+                bufferPosition += HANTEK_CHANNELS - 1 - channel;
+                for (unsigned pos = 0; pos < result.data[channel].size(); ++pos, bufferPosition += HANTEK_CHANNELS) {
+                    if (bufferPosition >= totalSampleCount) bufferPosition %= totalSampleCount;
+                    double dataBuf = (double)((int)(rawData[bufferPosition]));
+                    result.data[channel][pos] = (dataBuf / limit - offset) * gainStep;
+                }
+            }
+        }
+    }
+}
+
+double HantekDsoControl::getBestSamplerate(double samplerate, bool fastRate, bool maximum,
+                                           unsigned *downsampler) const {
     // Abort if the input value is invalid
     if (samplerate <= 0.0) return 0.0;
 
     double bestSamplerate = 0.0;
 
     // Get samplerate specifications for this mode and model
-    ControlSamplerateLimits *limits;
+    const ControlSamplerateLimits *limits;
     if (fastRate)
         limits = &(specification.samplerate.multi);
     else
         limits = &(specification.samplerate.single);
 
     // Get downsampling factor that would provide the requested rate
-    double bestDownsampler = (double)limits->base / specification.bufferDividers[controlsettings.recordLengthId] / samplerate;
+    double bestDownsampler =
+        (double)limits->base / specification.bufferDividers[controlsettings.recordLengthId] / samplerate;
     // Base samplerate sufficient, or is the maximum better?
     if (bestDownsampler < 1.0 &&
         (samplerate <= limits->max / specification.bufferDividers[controlsettings.recordLengthId] || !maximum)) {
@@ -694,30 +634,17 @@ double HantekDsoControl::getBestSamplerate(double samplerate, bool fastRate, boo
     return bestSamplerate;
 }
 
-/// \brief Get the count of samples that are expected returned by the scope.
-/// \param fastRate Is set to the state of the fast rate mode when provided.
-/// \return The total number of samples the scope should return.
-unsigned HantekDsoControl::getSampleCount(bool *fastRate) {
-    unsigned totalSampleCount = getRecordLength();
-    bool fastRateEnabled = controlsettings.samplerate.limits == &specification.samplerate.multi;
-
-    if (totalSampleCount == UINT_MAX) {
-        // Roll mode
-        const int packetSize = device->getPacketSize();
-        if (packetSize < 0)
-            totalSampleCount = UINT_MAX;
-        else
-            totalSampleCount = packetSize;
+unsigned HantekDsoControl::getSampleCount() const {
+    if (isRollMode()) {
+        return device->getPacketSize();
     } else {
-        if (!fastRateEnabled) totalSampleCount *= HANTEK_CHANNELS;
+        if (isFastRate())
+            return getRecordLength();
+        else
+            return getRecordLength() * HANTEK_CHANNELS;
     }
-    if (fastRate) *fastRate = fastRateEnabled;
-    return totalSampleCount;
 }
 
-/// \brief Sets the size of the sample buffer without updating dependencies.
-/// \param index The record length index that should be set.
-/// \return The record length that has been set, 0 on error.
 unsigned HantekDsoControl::updateRecordLength(unsigned index) {
     if (index >= (unsigned)controlsettings.samplerate.limits->recordLengths.size()) return 0;
 
@@ -754,7 +681,8 @@ unsigned HantekDsoControl::updateRecordLength(unsigned index) {
     }
 
     // Check if the divider has changed and adapt samplerate limits accordingly
-    bool bDividerChanged = specification.bufferDividers[index] != specification.bufferDividers[controlsettings.recordLengthId];
+    bool bDividerChanged =
+        specification.bufferDividers[index] != specification.bufferDividers[controlsettings.recordLengthId];
 
     controlsettings.recordLengthId = index;
 
@@ -768,11 +696,6 @@ unsigned HantekDsoControl::updateRecordLength(unsigned index) {
     return controlsettings.samplerate.limits->recordLengths[index];
 }
 
-/// \brief Sets the samplerate based on the parameters calculated by
-/// Control::getBestSamplerate.
-/// \param downsampler The downsampling factor.
-/// \param fastRate true, if one channel uses all buffers.
-/// \return The downsampling factor that has been set.
 unsigned HantekDsoControl::updateSamplerate(unsigned downsampler, bool fastRate) {
     // Get samplerate limits
     Hantek::ControlSamplerateLimits *limits =
@@ -872,8 +795,8 @@ unsigned HantekDsoControl::updateSamplerate(unsigned downsampler, bool fastRate)
 
     controlsettings.samplerate.downsampler = downsampler;
     if (downsampler)
-        controlsettings.samplerate.current =
-            controlsettings.samplerate.limits->base / specification.bufferDividers[controlsettings.recordLengthId] / downsampler;
+        controlsettings.samplerate.current = controlsettings.samplerate.limits->base /
+                                             specification.bufferDividers[controlsettings.recordLengthId] / downsampler;
     else
         controlsettings.samplerate.current =
             controlsettings.samplerate.limits->max / specification.bufferDividers[controlsettings.recordLengthId];
@@ -894,7 +817,6 @@ unsigned HantekDsoControl::updateSamplerate(unsigned downsampler, bool fastRate)
     return downsampler;
 }
 
-/// \brief Restore the samplerate/timebase targets after divider updates.
 void HantekDsoControl::restoreTargets() {
     if (controlsettings.samplerate.target.samplerateSet)
         this->setSamplerate();
@@ -902,7 +824,6 @@ void HantekDsoControl::restoreTargets() {
         this->setRecordTime();
 }
 
-/// \brief Update the minimum and maximum supported samplerate.
 void HantekDsoControl::updateSamplerateLimits() {
     // Works only if the minimum samplerate for normal mode is lower than for fast
     // rate mode, which is the case for all models
@@ -917,24 +838,24 @@ void HantekDsoControl::updateSamplerateLimits() {
 /// \brief Sets the size of the oscilloscopes sample buffer.
 /// \param index The record length index that should be set.
 /// \return The record length that has been set, 0 on error.
-unsigned HantekDsoControl::setRecordLength(unsigned index) {
-    if (!device->isConnected()) return 0;
+Dso::ErrorCode HantekDsoControl::setRecordLength(unsigned index) {
+    if (!device->isConnected()) return Dso::ErrorCode::ERROR_CONNECTION;
 
-    if (!this->updateRecordLength(index)) return 0;
+    if (!this->updateRecordLength(index)) return Dso::ErrorCode::ERROR_PARAMETER;
 
     this->restoreTargets();
     this->setPretriggerPosition(controlsettings.trigger.position);
 
     emit recordLengthChanged(getRecordLength());
-    return getRecordLength();
+    return Dso::ErrorCode::ERROR_NONE;
 }
 
 /// \brief Sets the samplerate of the oscilloscope.
 /// \param samplerate The samplerate that should be met (S/s), 0.0 to restore
 /// current samplerate.
 /// \return The samplerate that has been set, 0.0 on error.
-double HantekDsoControl::setSamplerate(double samplerate) {
-    if (!device->isConnected()) return 0.0;
+Dso::ErrorCode HantekDsoControl::setSamplerate(double samplerate) {
+    if (!device->isConnected()) return Dso::ErrorCode::ERROR_CONNECTION;
 
     if (samplerate == 0.0) {
         samplerate = controlsettings.samplerate.target.samplerate;
@@ -946,19 +867,19 @@ double HantekDsoControl::setSamplerate(double samplerate) {
     if (!specification.isSoftwareTriggerDevice) {
         // When possible, enable fast rate if it is required to reach the requested
         // samplerate
-        bool fastRate =
-            (controlsettings.usedChannels <= 1) &&
-            (samplerate > specification.samplerate.single.max / specification.bufferDividers[controlsettings.recordLengthId]);
+        bool fastRate = (controlsettings.usedChannels <= 1) &&
+                        (samplerate > specification.samplerate.single.max /
+                                          specification.bufferDividers[controlsettings.recordLengthId]);
 
         // What is the nearest, at least as high samplerate the scope can provide?
         unsigned downsampler = 0;
-        double bestSamplerate = getBestSamplerate(samplerate, fastRate, false, &(downsampler));
+        getBestSamplerate(samplerate, fastRate, false, &(downsampler));
 
         // Set the calculated samplerate
         if (this->updateSamplerate(downsampler, fastRate) == UINT_MAX)
-            return 0.0;
+            return Dso::ErrorCode::ERROR_PARAMETER;
         else {
-            return bestSamplerate;
+            return Dso::ErrorCode::ERROR_NONE;
         }
     } else {
         int sampleId;
@@ -977,7 +898,7 @@ double HantekDsoControl::setSamplerate(double samplerate) {
             emit recordTimeChanged((double)(getRecordLength() - sampleMargin) / controlsettings.samplerate.current);
         emit samplerateChanged(controlsettings.samplerate.current);
 
-        return samplerate;
+        return Dso::ErrorCode::ERROR_NONE;
     }
 }
 
@@ -985,8 +906,8 @@ double HantekDsoControl::setSamplerate(double samplerate) {
 /// \param duration The record time duration that should be met (s), 0.0 to
 /// restore current record time.
 /// \return The record time duration that has been set, 0.0 on error.
-double HantekDsoControl::setRecordTime(double duration) {
-    if (!device->isConnected()) return 0.0;
+Dso::ErrorCode HantekDsoControl::setRecordTime(double duration) {
+    if (!device->isConnected()) return Dso::ErrorCode::ERROR_CONNECTION;
 
     if (duration == 0.0) {
         duration = controlsettings.samplerate.target.duration;
@@ -1004,18 +925,17 @@ double HantekDsoControl::setRecordTime(double duration) {
         // When possible, enable fast rate if the record time can't be set that low
         // to improve resolution
         bool fastRate = (controlsettings.usedChannels <= 1) &&
-                        (maxSamplerate >=
-                         specification.samplerate.multi.base / specification.bufferDividers[controlsettings.recordLengthId]);
+                        (maxSamplerate >= specification.samplerate.multi.base /
+                                              specification.bufferDividers[controlsettings.recordLengthId]);
 
         // What is the nearest, at most as high samplerate the scope can provide?
         unsigned downsampler = 0;
-        double bestSamplerate = getBestSamplerate(maxSamplerate, fastRate, true, &(downsampler));
 
         // Set the calculated samplerate
         if (this->updateSamplerate(downsampler, fastRate) == UINT_MAX)
-            return 0.0;
+            return Dso::ErrorCode::ERROR_PARAMETER;
         else {
-            return (double)getRecordLength() / bestSamplerate;
+            return Dso::ErrorCode::ERROR_NONE;
         }
     } else {
         // For now - we go for the 10240 size sampling - the other seems not to be
@@ -1039,7 +959,7 @@ double HantekDsoControl::setRecordTime(double duration) {
         controlsettings.samplerate.current = specification.sampleSteps[sampleId];
 
         emit samplerateChanged(controlsettings.samplerate.current);
-        return controlsettings.samplerate.current;
+        return Dso::ErrorCode::ERROR_NONE;
     }
 }
 
@@ -1047,10 +967,10 @@ double HantekDsoControl::setRecordTime(double duration) {
 /// \param channel The channel that should be set.
 /// \param used true if the channel should be sampled.
 /// \return See ::Dso::ErrorCode.
-int HantekDsoControl::setChannelUsed(unsigned channel, bool used) {
-    if (!device->isConnected()) return Dso::ERROR_CONNECTION;
+Dso::ErrorCode HantekDsoControl::setChannelUsed(unsigned channel, bool used) {
+    if (!device->isConnected()) return Dso::ErrorCode::ERROR_CONNECTION;
 
-    if (channel >= HANTEK_CHANNELS) return Dso::ERROR_PARAMETER;
+    if (channel >= HANTEK_CHANNELS) return Dso::ErrorCode::ERROR_PARAMETER;
 
     // Update settings
     controlsettings.voltage[channel].used = used;
@@ -1105,17 +1025,17 @@ int HantekDsoControl::setChannelUsed(unsigned channel, bool used) {
 
     if (fastRateChanged) this->updateSamplerateLimits();
 
-    return Dso::ERROR_NONE;
+    return Dso::ErrorCode::ERROR_NONE;
 }
 
 /// \brief Set the coupling for the given channel.
 /// \param channel The channel that should be set.
 /// \param coupling The new coupling for the channel.
 /// \return See ::Dso::ErrorCode.
-int HantekDsoControl::setCoupling(unsigned channel, Dso::Coupling coupling) {
-    if (!device->isConnected()) return Dso::ERROR_CONNECTION;
+Dso::ErrorCode HantekDsoControl::setCoupling(unsigned channel, Dso::Coupling coupling) {
+    if (!device->isConnected()) return Dso::ErrorCode::ERROR_CONNECTION;
 
-    if (channel >= HANTEK_CHANNELS) return Dso::ERROR_PARAMETER;
+    if (channel >= HANTEK_CHANNELS) return Dso::ErrorCode::ERROR_PARAMETER;
 
     // SetRelays control command for coupling relays
     if (specification.supportsCouplingRelays) {
@@ -1124,17 +1044,18 @@ int HantekDsoControl::setCoupling(unsigned channel, Dso::Coupling coupling) {
         this->controlPending[CONTROLINDEX_SETRELAYS] = true;
     }
 
-    return Dso::ERROR_NONE;
+    return Dso::ErrorCode::ERROR_NONE;
 }
 
 /// \brief Sets the gain for the given channel.
+/// Get the actual gain by specification.gainSteps[gainId]
 /// \param channel The channel that should be set.
 /// \param gain The gain that should be met (V/div).
 /// \return The gain that has been set, ::Dso::ErrorCode on error.
-double HantekDsoControl::setGain(unsigned channel, double gain) {
-    if (!device->isConnected()) return Dso::ERROR_CONNECTION;
+Dso::ErrorCode HantekDsoControl::setGain(unsigned channel, double gain) {
+    if (!device->isConnected()) return Dso::ErrorCode::ERROR_CONNECTION;
 
-    if (channel >= HANTEK_CHANNELS) return Dso::ERROR_PARAMETER;
+    if (channel >= HANTEK_CHANNELS) return Dso::ErrorCode::ERROR_PARAMETER;
 
     // Find lowest gain voltage thats at least as high as the requested
     int gainId;
@@ -1168,30 +1089,25 @@ double HantekDsoControl::setGain(unsigned channel, double gain) {
 
     this->setOffset(channel, controlsettings.voltage[channel].offset);
 
-    return specification.gainSteps[gainId];
+    return Dso::ErrorCode::ERROR_NONE;
 }
 
 /// \brief Set the offset for the given channel.
+/// Get the actual offset for the channel from controlsettings.voltage[channel].offsetReal
 /// \param channel The channel that should be set.
 /// \param offset The new offset value (0.0 - 1.0).
-/// \return The offset that has been set, ::Dso::ErrorCode on error.
-double HantekDsoControl::setOffset(unsigned channel, double offset) {
-    if (!device->isConnected()) return Dso::ERROR_CONNECTION;
+Dso::ErrorCode HantekDsoControl::setOffset(unsigned channel, double offset) {
+    if (!device->isConnected()) return Dso::ErrorCode::ERROR_CONNECTION;
 
-    if (channel >= HANTEK_CHANNELS) return Dso::ERROR_PARAMETER;
+    if (channel >= HANTEK_CHANNELS) return Dso::ErrorCode::ERROR_PARAMETER;
 
+    unsigned short *channelOffLimit = specification.offsetLimit[channel][controlsettings.voltage[channel].gain];
     // Calculate the offset value
     // The range is given by the calibration data (convert from big endian)
-    unsigned short int minimum =
-        ((unsigned short int)*(
-             (unsigned char *)&(specification.offsetLimit[channel][controlsettings.voltage[channel].gain][OFFSET_START]))
-         << 8) +
-        *((unsigned char *)&(specification.offsetLimit[channel][controlsettings.voltage[channel].gain][OFFSET_START]) + 1);
-    unsigned short int maximum =
-        ((unsigned short int)*(
-             (unsigned char *)&(specification.offsetLimit[channel][controlsettings.voltage[channel].gain][OFFSET_END]))
-         << 8) +
-        *((unsigned char *)&(specification.offsetLimit[channel][controlsettings.voltage[channel].gain][OFFSET_END]) + 1);
+    unsigned short int minimum = ((unsigned short int)*((unsigned char *)&(channelOffLimit[OFFSET_START])) << 8) +
+                                 *((unsigned char *)&(channelOffLimit[OFFSET_START]) + 1);
+    unsigned short int maximum = ((unsigned short int)*((unsigned char *)&(channelOffLimit[OFFSET_END])) << 8) +
+                                 *((unsigned char *)&(channelOffLimit[OFFSET_END]) + 1);
     unsigned short int offsetValue = offset * (maximum - minimum) + minimum + 0.5;
     double offsetReal = (double)(offsetValue - minimum) / (maximum - minimum);
 
@@ -1205,28 +1121,29 @@ double HantekDsoControl::setOffset(unsigned channel, double offset) {
 
     this->setTriggerLevel(channel, controlsettings.trigger.level[channel]);
 
-    return offsetReal;
+    return Dso::ErrorCode::ERROR_NONE;
 }
 
 /// \brief Set the trigger mode.
 /// \return See ::Dso::ErrorCode.
-int HantekDsoControl::setTriggerMode(Dso::TriggerMode mode) {
-    if (!device->isConnected()) return Dso::ERROR_CONNECTION;
+Dso::ErrorCode HantekDsoControl::setTriggerMode(Dso::TriggerMode mode) {
+    if (!device->isConnected()) return Dso::ErrorCode::ERROR_CONNECTION;
 
-    if (mode < Dso::TRIGGERMODE_AUTO || mode >= Dso::TRIGGERMODE_COUNT) return Dso::ERROR_PARAMETER;
+    if (mode < Dso::TRIGGERMODE_AUTO || mode >= Dso::TRIGGERMODE_COUNT) return Dso::ErrorCode::ERROR_PARAMETER;
 
     controlsettings.trigger.mode = mode;
-    return Dso::ERROR_NONE;
+    return Dso::ErrorCode::ERROR_NONE;
 }
 
 /// \brief Set the trigger source.
 /// \param special true for a special channel (EXT, ...) as trigger source.
 /// \param id The number of the channel, that should be used as trigger.
 /// \return See ::Dso::ErrorCode.
-int HantekDsoControl::setTriggerSource(bool special, unsigned id) {
-    if (!device->isConnected()) return Dso::ERROR_CONNECTION;
+Dso::ErrorCode HantekDsoControl::setTriggerSource(bool special, unsigned id) {
+    if (!device->isConnected()) return Dso::ErrorCode::ERROR_CONNECTION;
 
-    if ((!special && id >= HANTEK_CHANNELS) || (special && id >= HANTEK_SPECIAL_CHANNELS)) return Dso::ERROR_PARAMETER;
+    if ((!special && id >= HANTEK_CHANNELS) || (special && id >= HANTEK_SPECIAL_CHANNELS))
+        return Dso::ErrorCode::ERROR_PARAMETER;
 
     switch (specification.command.bulk.setTrigger) {
     case BULK_SETTRIGGERANDSAMPLERATE:
@@ -1251,7 +1168,7 @@ int HantekDsoControl::setTriggerSource(bool special, unsigned id) {
         break;
 
     default:
-        return Dso::ERROR_UNSUPPORTED;
+        return Dso::ErrorCode::ERROR_UNSUPPORTED;
     }
 
     // SetRelays control command for external trigger relay
@@ -1269,32 +1186,27 @@ int HantekDsoControl::setTriggerSource(bool special, unsigned id) {
     } else
         this->setTriggerLevel(id, controlsettings.trigger.level[id]);
 
-    return Dso::ERROR_NONE;
+    return Dso::ErrorCode::ERROR_NONE;
 }
 
 /// \brief Set the trigger level.
 /// \param channel The channel that should be set.
 /// \param level The new trigger level (V).
 /// \return The trigger level that has been set, ::Dso::ErrorCode on error.
-double HantekDsoControl::setTriggerLevel(unsigned channel, double level) {
-    if (!device->isConnected()) return Dso::ERROR_CONNECTION;
+Dso::ErrorCode HantekDsoControl::setTriggerLevel(unsigned channel, double level) {
+    if (!device->isConnected()) return Dso::ErrorCode::ERROR_CONNECTION;
 
-    if (channel >= HANTEK_CHANNELS) return Dso::ERROR_PARAMETER;
+    if (channel >= HANTEK_CHANNELS) return Dso::ErrorCode::ERROR_PARAMETER;
 
     // Calculate the trigger level value
-    unsigned short int minimum, maximum;
-    if (specification.sampleSize>8) {
+    unsigned short minimum, maximum;
+    if (specification.sampleSize > 8) {
+        const unsigned short *offsetLimit = specification.offsetLimit[channel][controlsettings.voltage[channel].gain];
         // The range is the same as used for the offsets for 10 bit models
-        minimum =
-            ((unsigned short int)*(
-                 (unsigned char *)&(specification.offsetLimit[channel][controlsettings.voltage[channel].gain][OFFSET_START]))
-             << 8) +
-            *((unsigned char *)&(specification.offsetLimit[channel][controlsettings.voltage[channel].gain][OFFSET_START]) + 1);
-        maximum =
-            ((unsigned short int)*(
-                 (unsigned char *)&(specification.offsetLimit[channel][controlsettings.voltage[channel].gain][OFFSET_END]))
-             << 8) +
-            *((unsigned char *)&(specification.offsetLimit[channel][controlsettings.voltage[channel].gain][OFFSET_END]) + 1);
+        minimum = ((unsigned short int)*((unsigned char *)&(offsetLimit[OFFSET_START])) << 8) +
+                  *((unsigned char *)&(offsetLimit[OFFSET_START]) + 1);
+        maximum = ((unsigned short int)*((unsigned char *)&(offsetLimit[OFFSET_END])) << 8) +
+                  *((unsigned char *)&(offsetLimit[OFFSET_END]) + 1);
     } else {
         // It's from 0x00 to 0xfd for the 8 bit models
         minimum = 0x00;
@@ -1302,14 +1214,10 @@ double HantekDsoControl::setTriggerLevel(unsigned channel, double level) {
     }
 
     // Never get out of the limits
-    unsigned short int levelValue =
-        qBound((long int)minimum,
-               (long int)((controlsettings.voltage[channel].offsetReal +
-                           level / specification.gainSteps[controlsettings.voltage[channel].gain]) *
-                              (maximum - minimum) +
-                          0.5) +
-                   minimum,
-               (long int)maximum);
+    const double offsetReal = controlsettings.voltage[channel].offsetReal;
+    const double gainStep = specification.gainSteps[controlsettings.voltage[channel].gain];
+    unsigned short levelValue = qBound(
+        minimum, (unsigned short)(((offsetReal + level / gainStep) * (maximum - minimum) + 0.5) + minimum), maximum);
 
     // Check if the set channel is the trigger source
     if (!controlsettings.trigger.special && channel == controlsettings.trigger.source && specification.supportsOffset) {
@@ -1321,17 +1229,16 @@ double HantekDsoControl::setTriggerLevel(unsigned channel, double level) {
     /// \todo Get alternating trigger in here
 
     controlsettings.trigger.level[channel] = level;
-    return (double)((levelValue - minimum) / (maximum - minimum) - controlsettings.voltage[channel].offsetReal) *
-           specification.gainSteps[controlsettings.voltage[channel].gain];
+    return Dso::ErrorCode::ERROR_NONE;
 }
 
 /// \brief Set the trigger slope.
 /// \param slope The Slope that should cause a trigger.
 /// \return See ::Dso::ErrorCode.
-int HantekDsoControl::setTriggerSlope(Dso::Slope slope) {
-    if (!device->isConnected()) return Dso::ERROR_CONNECTION;
+Dso::ErrorCode HantekDsoControl::setTriggerSlope(Dso::Slope slope) {
+    if (!device->isConnected()) return Dso::ErrorCode::ERROR_CONNECTION;
 
-    if (slope >= Dso::SLOPE_COUNT) return Dso::ERROR_PARAMETER;
+    if (slope >= Dso::SLOPE_COUNT) return Dso::ErrorCode::ERROR_PARAMETER;
 
     switch (specification.command.bulk.setTrigger) {
     case BULK_SETTRIGGERANDSAMPLERATE: {
@@ -1353,23 +1260,20 @@ int HantekDsoControl::setTriggerSlope(Dso::Slope slope) {
         break;
     }
     default:
-        return Dso::ERROR_UNSUPPORTED;
+        return Dso::ErrorCode::ERROR_UNSUPPORTED;
     }
 
     controlsettings.trigger.slope = slope;
-    return Dso::ERROR_NONE;
+    return Dso::ErrorCode::ERROR_NONE;
 }
 
-int HantekDsoControl::forceTrigger() {
-    commandPending[BULK_FORCETRIGGER] = true;
-    return 0;
-}
+void HantekDsoControl::forceTrigger() { commandPending[BULK_FORCETRIGGER] = true; }
 
 /// \brief Set the trigger position.
 /// \param position The new trigger position (in s).
 /// \return The trigger position that has been set.
-double HantekDsoControl::setPretriggerPosition(double position) {
-    if (!device->isConnected()) return -2;
+Dso::ErrorCode HantekDsoControl::setPretriggerPosition(double position) {
+    if (!device->isConnected()) return Dso::ErrorCode::ERROR_CONNECTION;
 
     // All trigger positions are measured in samples
     unsigned positionSamples = position * controlsettings.samplerate.current;
@@ -1415,23 +1319,23 @@ double HantekDsoControl::setPretriggerPosition(double position) {
         break;
     }
     default:
-        return Dso::ERROR_UNSUPPORTED;
+        return Dso::ErrorCode::ERROR_UNSUPPORTED;
     }
 
     controlsettings.trigger.position = position;
-    return (double)positionSamples / controlsettings.samplerate.current;
+    return Dso::ErrorCode::ERROR_NONE;
 }
 
-int HantekDsoControl::stringCommand(const QString &commandString) {
-    if (!device->isConnected()) return Dso::ERROR_CONNECTION;
+Dso::ErrorCode HantekDsoControl::stringCommand(const QString &commandString) {
+    if (!device->isConnected()) return Dso::ErrorCode::ERROR_CONNECTION;
 
     QStringList commandParts = commandString.split(' ', QString::SkipEmptyParts);
 
-    if (commandParts.count() < 1) return Dso::ERROR_PARAMETER;
+    if (commandParts.count() < 1) return Dso::ErrorCode::ERROR_PARAMETER;
 
-    if (commandParts[0] != "send") return Dso::ERROR_UNSUPPORTED;
+    if (commandParts[0] != "send") return Dso::ErrorCode::ERROR_UNSUPPORTED;
 
-    if (commandParts.count() < 2) return Dso::ERROR_PARAMETER;
+    if (commandParts.count() < 2) return Dso::ErrorCode::ERROR_PARAMETER;
 
     if (commandParts[1] == "bulk") {
         QString data = commandString.section(' ', 2, -1, QString::SectionSkipEmpty);
@@ -1439,12 +1343,12 @@ int HantekDsoControl::stringCommand(const QString &commandString) {
 
         // Read command code (First byte)
         hexParse(commandParts[2], &commandCode, 1);
-        if (commandCode > BULK_COUNT) return Dso::ERROR_UNSUPPORTED;
+        if (commandCode > BULK_COUNT) return Dso::ErrorCode::ERROR_UNSUPPORTED;
 
         // Update bulk command and mark as pending
         hexParse(data, command[commandCode]->data(), command[commandCode]->getSize());
         commandPending[commandCode] = true;
-        return Dso::ERROR_NONE;
+        return Dso::ErrorCode::ERROR_NONE;
     } else if (commandParts[1] == "control") {
         unsigned char controlCode = 0;
 
@@ -1454,16 +1358,16 @@ int HantekDsoControl::stringCommand(const QString &commandString) {
         for (cIndex = 0; cIndex < CONTROLINDEX_COUNT; ++cIndex) {
             if (this->controlCode[cIndex] == controlCode) break;
         }
-        if (cIndex >= CONTROLINDEX_COUNT) return Dso::ERROR_UNSUPPORTED;
+        if (cIndex >= CONTROLINDEX_COUNT) return Dso::ErrorCode::ERROR_UNSUPPORTED;
 
         QString data = commandString.section(' ', 3, -1, QString::SectionSkipEmpty);
 
         // Update control command and mark as pending
         hexParse(data, this->control[cIndex]->data(), this->control[cIndex]->getSize());
         this->controlPending[cIndex] = true;
-        return Dso::ERROR_NONE;
+        return Dso::ErrorCode::ERROR_NONE;
     } else
-        return Dso::ERROR_UNSUPPORTED;
+        return Dso::ErrorCode::ERROR_UNSUPPORTED;
 }
 
 void HantekDsoControl::run() {
@@ -1479,11 +1383,8 @@ void HantekDsoControl::run() {
         errorCode = device->bulkCommand(command[cIndex]);
         if (errorCode < 0) {
             qWarning("Sending bulk command %02x failed: %s", cIndex, libUsbErrorString(errorCode).toLocal8Bit().data());
-
-            if (errorCode == LIBUSB_ERROR_NO_DEVICE) {
-                emit communicationError();
-                return;
-            }
+            emit communicationError();
+            return;
         } else
             commandPending[cIndex] = false;
     }
@@ -1570,13 +1471,13 @@ void HantekDsoControl::run() {
 
             break;
 
-        case ROLL_GETDATA:
-            // Get data and process it, if we're still sampling
-            errorCode = this->getSamples(this->_samplingStarted);
-            if (errorCode < 0)
-                qWarning("Getting sample data failed: %s", libUsbErrorString(errorCode).toLocal8Bit().data());
-            else
-                timestampDebug(QString("Received %1 B of sampling data").arg(errorCode));
+        case ROLL_GETDATA: {
+            std::vector<unsigned char> rawData = this->getSamples(previousSampleCount);
+            if (this->_samplingStarted) {
+                convertRawDataToSamples(rawData);
+                emit samplesAvailable();
+            }
+        }
 
             // Check if we're in single trigger mode
             if (controlsettings.trigger.mode == Dso::TRIGGERMODE_SINGLE && this->_samplingStarted) this->stopSampling();
@@ -1598,23 +1499,25 @@ void HantekDsoControl::run() {
         this->rollState = ROLL_STARTSAMPLING;
 
         const int lastCaptureState = this->captureState;
-        this->captureState = this->getCaptureState();
-        if (this->captureState < 0)
-            qWarning("Getting capture state failed: %s", libUsbErrorString(this->captureState).toLocal8Bit().data());
-
-        else if (this->captureState != lastCaptureState)
+        unsigned triggerPoint;
+        std::tie(captureState, triggerPoint) = this->getCaptureState();
+        controlsettings.trigger.point = calculateTriggerPoint(triggerPoint);
+        if (this->captureState < 0) {
+            qWarning() << tr("Getting capture state failed: %1").arg(libUsbErrorString(this->captureState));
+            emit statusMessage(tr("Getting capture state failed: %1").arg(libUsbErrorString(this->captureState)), 0);
+        } else if (this->captureState != lastCaptureState)
             timestampDebug(QString("Capture state changed to %1").arg(this->captureState));
 
         switch (this->captureState) {
         case CAPTURE_READY:
         case CAPTURE_READY2250:
-        case CAPTURE_READY5200:
-            // Get data and process it, if we're still sampling
-            errorCode = this->getSamples(this->_samplingStarted);
-            if (errorCode < 0)
-                qWarning("Getting sample data failed: %s", libUsbErrorString(errorCode).toLocal8Bit().data());
-            else
-                timestampDebug(QString("Received %1 B of sampling data").arg(errorCode));
+        case CAPTURE_READY5200: {
+            std::vector<unsigned char> rawData = this->getSamples(previousSampleCount);
+            if (this->_samplingStarted) {
+                convertRawDataToSamples(rawData);
+                emit samplesAvailable();
+            }
+        }
 
             // Check if we're in single trigger mode
             if (controlsettings.trigger.mode == Dso::TRIGGERMODE_SINGLE && this->_samplingStarted) this->stopSampling();

--- a/openhantek/src/hantek/hantekdsocontrol.h
+++ b/openhantek/src/hantek/hantekdsocontrol.h
@@ -27,10 +27,13 @@ class HantekDsoControl : public QObject {
      * Creates a dsoControl object. The actual event loop / timer is not started.
      * You can optionally create a thread and move the created object to the
      * thread.
-     * You need to call updateInterval() to start the timer.
-     * @param device
+     * You need to call updateInterval() to start the timer. This is done implicitly
+     * if run() is called.
+     * @param device The usb device. This object does not take ownership.
      */
     HantekDsoControl(USBDevice *device);
+
+    /// \brief Cleans up
     ~HantekDsoControl();
 
     /// Call this to start the processing. This method will call itself
@@ -39,13 +42,29 @@ class HantekDsoControl : public QObject {
     /// there.
     void run();
 
+    /// \brief Gets the physical channel count for this oscilloscope.
+    /// \return The number of physical channels.
     unsigned getChannelCount();
-    QList<unsigned> *getAvailableRecordLengths();
+
+    /// \brief Get available record lengths for this oscilloscope.
+    /// \return The number of physical channels, empty list for continuous.
+    const std::vector<unsigned> &getAvailableRecordLengths();
+
+    /// \brief Get minimum samplerate for this oscilloscope.
+    /// \return The minimum samplerate for the current configuration in S/s.
     double getMinSamplerate();
+
+    /// \brief Get maximum samplerate for this oscilloscope.
+    /// \return The maximum samplerate for the current configuration in S/s.
     double getMaxSamplerate();
 
+    /// \brief Get a list of the names of the special trigger sources.
     const QStringList *getSpecialTriggerSources();
+
+    /// Return the associated usb device.
     const USBDevice *getDevice() const;
+
+    /// Return the last sample set
     const DSOsamples &getLastSamples();
 
     /// \brief Sends bulk/control commands directly.
@@ -59,63 +78,91 @@ class HantekDsoControl : public QObject {
     /// </p>
     /// \param command The command as string (Has to be parsed).
     /// \return See ::Dso::ErrorCode.
-    int stringCommand(const QString &commandString);
-  signals:
-    void samplingStarted();                                  ///< The oscilloscope started sampling/waiting for trigger
-    void samplingStopped();                                  ///< The oscilloscope stopped sampling/waiting for trigger
-    void statusMessage(const QString &message, int timeout); ///< Status message about the oscilloscope
-    void samplesAvailable();                                 ///< New sample data is available
+    Dso::ErrorCode stringCommand(const QString &commandString);
 
-    void availableRecordLengthsChanged(const QList<unsigned> &recordLengths); ///< The available record
-                                                                              /// lengths, empty list for
-    /// continuous
-    void samplerateLimitsChanged(double minimum, double maximum); ///< The minimum or maximum samplerate has changed
-    void recordLengthChanged(unsigned long duration);             ///< The record length has changed
-    void recordTimeChanged(double duration);                      ///< The record time duration has changed
-    void samplerateChanged(double samplerate);                    ///< The samplerate has changed
-    void samplerateSet(int mode, QList<double> sampleSteps);      ///< The samplerate has changed
+  private:
+    bool isRollMode() const;
+    bool isFastRate() const;
+    int getRecordLength() const;
 
-    void communicationError();
+    /// \brief Calculated the nearest samplerate supported by the oscilloscope.
+    /// \param samplerate The target samplerate, that should be met as good as
+    /// possible.
+    /// \param fastRate true, if the fast rate mode is enabled.
+    /// \param maximum The target samplerate is the maximum allowed when true, the
+    /// minimum otherwise.
+    /// \param downsampler Pointer to where the selected downsampling factor should
+    /// be written.
+    /// \return The nearest samplerate supported, 0.0 on error.
+    double getBestSamplerate(double samplerate, bool fastRate = false, bool maximum = false,
+                             unsigned *downsampler = 0) const;
 
-  protected:
-    bool isRollMode();
-    int getRecordLength();
+    /// Get the number of samples that are expected returned by the scope.
+    /// In rolling mode this is depends on the usb speed and packet size.
+    /// \return The total number of samples the scope should return.
+    unsigned getSampleCount() const;
+
     void updateInterval();
-    unsigned calculateTriggerPoint(unsigned value);
-    int getCaptureState();
-    int getSamples(bool process);
-    double getBestSamplerate(double samplerate, bool fastRate = false, bool maximum = false, unsigned *downsampler = 0);
-    unsigned getSampleCount(bool *fastRate = 0);
+
+    /// \brief Calculates the trigger point from the CommandGetCaptureState data.
+    /// \param value The data value that contains the trigger point.
+    /// \return The calculated trigger point for the given data.
+    static unsigned calculateTriggerPoint(unsigned value);
+
+    /// \brief Gets the current state.
+    /// \return The current CaptureState of the oscilloscope.
+    std::pair<int, unsigned> getCaptureState() const;
+
+    /// \brief Gets sample data from the oscilloscope
+    std::vector<unsigned char> getSamples(unsigned &previousSampleCount) const;
+
+    /// \brief Converts raw oscilloscope data to sample data
+    void convertRawDataToSamples(const std::vector<unsigned char> &rawData);
+
+    /// \brief Sets the size of the sample buffer without updating dependencies.
+    /// \param index The record length index that should be set.
+    /// \return The record length that has been set, 0 on error.
     unsigned updateRecordLength(unsigned size);
+
+    /// \brief Sets the samplerate based on the parameters calculated by
+    /// Control::getBestSamplerate.
+    /// \param downsampler The downsampling factor.
+    /// \param fastRate true, if one channel uses all buffers.
+    /// \return The downsampling factor that has been set.
     unsigned updateSamplerate(unsigned downsampler, bool fastRate);
+
+    /// \brief Restore the samplerate/timebase targets after divider updates.
     void restoreTargets();
+
+    /// \brief Update the minimum and maximum supported samplerate.
     void updateSamplerateLimits();
 
+  private:
     // Communication with device
     USBDevice *device;     ///< The USB device for the oscilloscope
     bool sampling = false; ///< true, if the oscilloscope is taking samples
 
-    QStringList specialTriggerSources = {tr("EXT"),tr("EXT/10")}; ///< Names of the special trigger sources
+    QStringList specialTriggerSources = {tr("EXT"), tr("EXT/10")}; ///< Names of the special trigger sources
 
     DataArray<unsigned char> *command[Hantek::BULK_COUNT] = {0}; ///< Pointers to bulk
-                                                           /// commands, ready to
+                                                                 /// commands, ready to
     /// be transmitted
-    bool commandPending[Hantek::BULK_COUNT] = {false};                       ///< true, when the command should be
-                                                                   /// executed
+    bool commandPending[Hantek::BULK_COUNT] = {false};                   ///< true, when the command should be
+                                                                         /// executed
     DataArray<unsigned char> *control[Hantek::CONTROLINDEX_COUNT] = {0}; ///< Pointers to control commands
-    unsigned char controlCode[Hantek::CONTROLINDEX_COUNT];         ///< Request codes for
-                                                                   /// control commands
-    bool controlPending[Hantek::CONTROLINDEX_COUNT]= {false};               ///< true, when the control
+    unsigned char controlCode[Hantek::CONTROLINDEX_COUNT];               ///< Request codes for
+                                                                         /// control commands
+    bool controlPending[Hantek::CONTROLINDEX_COUNT] = {false};           ///< true, when the control
     /// command should be executed
 
     // Device setup
     Hantek::ControlSpecification specification; ///< The specifications of the device
-    Hantek::ControlSettings controlsettings;           ///< The current settings of the device
+    Hantek::ControlSettings controlsettings;    ///< The current settings of the device
 
     // Results
     DSOsamples result;
     unsigned previousSampleCount = 0; ///< The expected total number of samples at
-                                  /// the last check before sampling started
+                                      /// the last check before sampling started
 
     // State of the communication thread
     int captureState = Hantek::CAPTURE_WAITING;
@@ -130,19 +177,36 @@ class HantekDsoControl : public QObject {
     void startSampling();
     void stopSampling();
 
-    unsigned setRecordLength(unsigned size);
-    double setSamplerate(double samplerate = 0.0);
-    double setRecordTime(double duration = 0.0);
+    Dso::ErrorCode setRecordLength(unsigned size);
+    Dso::ErrorCode setSamplerate(double samplerate = 0.0);
+    Dso::ErrorCode setRecordTime(double duration = 0.0);
 
-    int setChannelUsed(unsigned channel, bool used);
-    int setCoupling(unsigned channel, Dso::Coupling coupling);
-    double setGain(unsigned channel, double gain);
-    double setOffset(unsigned channel, double offset);
+    Dso::ErrorCode setChannelUsed(unsigned channel, bool used);
+    Dso::ErrorCode setCoupling(unsigned channel, Dso::Coupling coupling);
+    Dso::ErrorCode setGain(unsigned channel, double gain);
+    Dso::ErrorCode setOffset(unsigned channel, double offset);
 
-    int setTriggerMode(Dso::TriggerMode mode);
-    int setTriggerSource(bool special, unsigned id);
-    double setTriggerLevel(unsigned channel, double level);
-    int setTriggerSlope(Dso::Slope slope);
-    double setPretriggerPosition(double position);
-    int forceTrigger();
+    Dso::ErrorCode setTriggerMode(Dso::TriggerMode mode);
+    Dso::ErrorCode setTriggerSource(bool special, unsigned id);
+    Dso::ErrorCode setTriggerLevel(unsigned channel, double level);
+    Dso::ErrorCode setTriggerSlope(Dso::Slope slope);
+    Dso::ErrorCode setPretriggerPosition(double position);
+    void forceTrigger();
+
+  signals:
+    void samplingStarted();                                  ///< The oscilloscope started sampling/waiting for trigger
+    void samplingStopped();                                  ///< The oscilloscope stopped sampling/waiting for trigger
+    void statusMessage(const QString &message, int timeout); ///< Status message about the oscilloscope
+    void samplesAvailable();                                 ///< New sample data is available
+
+    void availableRecordLengthsChanged(const std::vector<unsigned> &recordLengths); ///< The available record
+                                                                                    /// lengths, empty list for
+
+    void samplerateLimitsChanged(double minimum, double maximum); ///< The minimum or maximum samplerate has changed
+    void recordLengthChanged(unsigned long duration);             ///< The record length has changed
+    void recordTimeChanged(double duration);                      ///< The record time duration has changed
+    void samplerateChanged(double samplerate);                    ///< The samplerate has changed
+    void samplerateSet(int mode, QList<double> sampleSteps);      ///< The samplerate has changed
+
+    void communicationError() const;
 };

--- a/openhantek/src/hantek/stateStructs.h
+++ b/openhantek/src/hantek/stateStructs.h
@@ -77,10 +77,10 @@ struct ControlSpecificationCommands {
 /// \struct ControlSamplerateLimits                           hantek/control.h
 /// \brief Stores the samplerate limits for calculations.
 struct ControlSamplerateLimits {
-    double base;                       ///< The base for sample rate calculations
-    double max;                        ///< The maximum sample rate
-    unsigned int maxDownsampler;       ///< The maximum downsampling ratio
-    QList<unsigned int> recordLengths; ///< Available record lengths, UINT_MAX means rolling
+    double base;                         ///< The base for sample rate calculations
+    double max;                          ///< The maximum sample rate
+    unsigned int maxDownsampler;         ///< The maximum downsampling ratio
+    std::vector<unsigned> recordLengths; ///< Available record lengths, UINT_MAX means rolling
 };
 
 //////////////////////////////////////////////////////////////////////////////
@@ -106,7 +106,7 @@ struct ControlSpecification {
 
     // Calibration
     /// The sample values at the top of the screen
-    QList<unsigned short int> voltageLimit[HANTEK_CHANNELS];
+    QList<unsigned short> voltageLimit[HANTEK_CHANNELS];
     /// The index of the selected gain on the hardware
     QList<unsigned char> gainIndex;
     QList<unsigned char> gainDiv;
@@ -114,9 +114,9 @@ struct ControlSpecification {
     QList<unsigned char> sampleDiv;
     /// Calibration data for the channel offsets \todo Should probably be a QList
     /// too
-    unsigned short int offsetLimit[HANTEK_CHANNELS][9][OFFSET_COUNT];
+    unsigned short offsetLimit[HANTEK_CHANNELS][9][OFFSET_COUNT];
 
-    bool isSoftwareTriggerDevice=false;
+    bool isSoftwareTriggerDevice = false;
     bool useControlNoBulk = false;
     bool supportsCaptureState = true;
     bool supportsOffset = true;
@@ -159,7 +159,7 @@ struct ControlSettingsTrigger {
 /// \struct ControlSettingsVoltage                            hantek/control.h
 /// \brief Stores the current amplification settings of the device.
 struct ControlSettingsVoltage {
-    unsigned int gain; ///< The gain id
+    unsigned gain;     ///< The gain id
     double offset;     ///< The screen offset for each channel
     double offsetReal; ///< The real offset for each channel (Due to quantization)
     bool used;         ///< true, if the channel is used

--- a/openhantek/src/hantek/usb/usbdevice.cpp
+++ b/openhantek/src/hantek/usb/usbdevice.cpp
@@ -2,6 +2,7 @@
 
 #include <QCoreApplication>
 #include <QList>
+#include <iostream>
 
 #include "usbdevice.h"
 
@@ -170,7 +171,7 @@ int USBDevice::bulkCommand(DataArray<unsigned char> *command, int attempts) {
 /// \param length The length of data contained in the packets.
 /// \param attempts The number of attempts, that are done on timeouts.
 /// \return Number of received bytes on success, libusb error code on error.
-int USBDevice::bulkReadMulti(unsigned char *data, unsigned int length, int attempts) {
+int USBDevice::bulkReadMulti(unsigned char *data, unsigned length, int attempts) {
     if (!this->handle) return LIBUSB_ERROR_NO_DEVICE;
 
     int errorCode = 0;
@@ -261,17 +262,16 @@ int USBDevice::getConnectionSpeed() {
 /// \brief Gets the maximum size of one packet transmitted via bulk transfer.
 /// \return The maximum packet size in bytes, -1 on error.
 int USBDevice::getPacketSize() {
-    switch (this->getConnectionSpeed()) {
-    case CONNECTION_FULLSPEED:
+    const int s = this->getConnectionSpeed();
+    if (s == CONNECTION_FULLSPEED)
         return 64;
-        break;
-    case CONNECTION_HIGHSPEED:
+    else if (s == CONNECTION_HIGHSPEED)
         return 512;
-        break;
-    default:
-        return -1;
-        break;
+    else if (s > CONNECTION_HIGHSPEED) {
+        std::cerr << "Unknown USB speed. Please correct source code in USBDevice::getPacketSize()" << std::endl;
+        throw new std::runtime_error("Unknown USB speed");
     }
+    return -1;
 }
 
 /// \brief Get the oscilloscope model.
@@ -282,12 +282,6 @@ libusb_device *USBDevice::getRawDevice() const { return device; }
 
 const DSOModel &USBDevice::getModel() const { return model; }
 
-void USBDevice::setEnableBulkTransfer(bool enable)
-{
-    allowBulkTransfer = enable;
-}
+void USBDevice::setEnableBulkTransfer(bool enable) { allowBulkTransfer = enable; }
 
-void USBDevice::overwriteInPacketLength(int len)
-{
-    inPacketLength = len;
-}
+void USBDevice::overwriteInPacketLength(int len) { inPacketLength = len; }

--- a/openhantek/src/hantek/usb/usbdevice.h
+++ b/openhantek/src/hantek/usb/usbdevice.h
@@ -48,7 +48,7 @@ class USBDevice : public QObject {
     int bulkRead(unsigned char *data, unsigned int length, int attempts = HANTEK_ATTEMPTS);
 
     int bulkCommand(DataArray<unsigned char> *command, int attempts = HANTEK_ATTEMPTS);
-    int bulkReadMulti(unsigned char *data, unsigned int length, int attempts = HANTEK_ATTEMPTS_MULTI);
+    int bulkReadMulti(unsigned char *data, unsigned length, int attempts = HANTEK_ATTEMPTS_MULTI);
 
     int controlTransfer(unsigned char type, unsigned char request, unsigned char *data, unsigned int length, int value,
                         int index, int attempts = HANTEK_ATTEMPTS);

--- a/openhantek/src/main.cpp
+++ b/openhantek/src/main.cpp
@@ -93,19 +93,22 @@ int main(int argc, char *argv[]) {
         QString modelName = QString::fromStdString(i->getModel().name);
 
         if (i->needsFirmware()) {
-            w->addItem(QCoreApplication::translate("Firmware upload dialog", "%1: Firmware upload failed").arg(modelName));
+            w->addItem(
+                QCoreApplication::translate("Firmware upload dialog", "%1: Firmware upload failed").arg(modelName));
             continue;
         }
         QString errorMessage;
         if (i->connectDevice(errorMessage)) {
             w->addItem(QCoreApplication::translate("Firmware upload dialog", "%1: Ready").arg(modelName));
-            w->setCurrentRow(w->count()-1);
+            w->setCurrentRow(w->count() - 1);
         } else {
-            w->addItem(QCoreApplication::translate("Firmware upload dialog", "%1: %2").arg(modelName).arg(findDevices.getErrorMessage()));
+            w->addItem(QCoreApplication::translate("Firmware upload dialog", "%1: %2")
+                           .arg(modelName)
+                           .arg(findDevices.getErrorMessage()));
         }
     }
 
-    if (w->currentRow() == -1 || devices.size()>1) {
+    if (w->currentRow() == -1 || devices.size() > 1) {
         QPushButton *btn = new QPushButton(QCoreApplication::translate("", "Connect to first device"), dialog.get());
         dialog->move(QApplication::desktop()->screen()->rect().center() - w->rect().center());
         dialog->setWindowTitle(QCoreApplication::translate("", "Firmware upload"));

--- a/openhantek/src/mainwindow.cpp
+++ b/openhantek/src/mainwindow.cpp
@@ -262,12 +262,12 @@ void OpenHantekMainWindow::addManualCommandEdit() {
         commandEdit->setFocus();
     });
     connect(commandEdit, &QLineEdit::returnPressed, [this]() {
-        int errorCode = dsoControl->stringCommand(commandEdit->text());
+        Dso::ErrorCode errorCode = dsoControl->stringCommand(commandEdit->text());
 
         commandEdit->hide();
         commandEdit->clear();
 
-        if (errorCode < 0) statusBar()->showMessage(tr("Invalid command"), 3000);
+        if (errorCode != Dso::ErrorCode::ERROR_NONE) statusBar()->showMessage(tr("Invalid command"), 3000);
     });
 }
 
@@ -343,10 +343,12 @@ void OpenHantekMainWindow::applySettingsToDevice() {
         samplerateSelected();
     else
         timebaseSelected();
-    if (dsoControl->getAvailableRecordLengths()->isEmpty())
+    if (dsoControl->getAvailableRecordLengths().empty())
         dsoControl->setRecordLength(settings->scope.horizontal.recordLength);
     else {
-        int index = dsoControl->getAvailableRecordLengths()->indexOf(settings->scope.horizontal.recordLength);
+        auto recLenVec = dsoControl->getAvailableRecordLengths();
+        ptrdiff_t index = std::distance(
+            recLenVec.begin(), std::find(recLenVec.begin(), recLenVec.end(), settings->scope.horizontal.recordLength));
         dsoControl->setRecordLength(index < 0 ? 1 : index);
     }
     dsoControl->setTriggerMode(settings->scope.trigger.mode);

--- a/openhantek/src/scopesettings.h
+++ b/openhantek/src/scopesettings.h
@@ -55,8 +55,8 @@ struct DsoSettingsScopeVoltage {
 /// \struct DsoSettingsScope                                          settings.h
 /// \brief Holds the settings for the oscilloscope.
 struct DsoSettingsScope {
-    DsoSettingsScopeHorizontal horizontal;    ///< Settings for the horizontal axis
-    DsoSettingsScopeTrigger trigger;          ///< Settings for the trigger
+    DsoSettingsScopeHorizontal horizontal;      ///< Settings for the horizontal axis
+    DsoSettingsScopeTrigger trigger;            ///< Settings for the trigger
     QVector<DsoSettingsScopeSpectrum> spectrum; ///< Spectrum analysis settings
     QVector<DsoSettingsScopeVoltage> voltage;   ///< Settings for the normal graphs
 

--- a/readme.md
+++ b/readme.md
@@ -22,7 +22,7 @@ Navigate to the [Releases](https://github.com/OpenHantek/openhantek/releases) pa
 ## Building OpenHantek from source
 You need the following packages, to build OpenHantek from source:
 * CMake 3.5+
-* Qt 5.3+
+* Qt 5.4+
 * FFTW 3+ (prebuild files will be downloaded on windows)
 * libusb 1.x (prebuild files will be used on windows)
 


### PR DESCRIPTION
* Minimum Qt version is Qt5.4 now (10th Dec 2014)
* Move fft window pointer from dataanalyzerresult to dataanalyzer. Use smart pointers for all in-between allocations
* Use QSignalBlocker instead of boolean flags in HorizontalDock
* Fix some int signess warnings
* usbdevice: Use if/else instead of switch for getPacketSize and fail with a std::runtime_error if result is unexpected
* hantekdsocontrol: Modernize and make it more readable. Use const on all get methods. Use error enum consistently
