### PR TITLE
Add checkbox to display inverted channels, take 2

### DIFF
--- a/openhantek/src/docks/VoltageDock.cpp
+++ b/openhantek/src/docks/VoltageDock.cpp
@@ -47,6 +47,8 @@ VoltageDock::VoltageDock(DsoSettings *settings, QWidget *parent, Qt::WindowFlags
         this->gainComboBox.append(new QComboBox());
         this->gainComboBox[channel]->addItems(this->gainStrings);
 
+        this->invertCheckBox.append(new QCheckBox(tr("Invert")));
+
         this->usedCheckBox.append(new QCheckBox(settings->scope.voltage[channel].name));
     }
 
@@ -54,9 +56,10 @@ VoltageDock::VoltageDock(DsoSettings *settings, QWidget *parent, Qt::WindowFlags
     this->dockLayout->setColumnMinimumWidth(0, 64);
     this->dockLayout->setColumnStretch(1, 1);
     for (int channel = 0; channel < settings->scope.voltage.count(); ++channel) {
-        this->dockLayout->addWidget(this->usedCheckBox[channel], channel * 2, 0);
-        this->dockLayout->addWidget(this->gainComboBox[channel], channel * 2, 1);
-        this->dockLayout->addWidget(this->miscComboBox[channel], channel * 2 + 1, 1);
+        this->dockLayout->addWidget(this->usedCheckBox[channel], channel * 3, 0);
+        this->dockLayout->addWidget(this->gainComboBox[channel], channel * 3, 1);
+        this->dockLayout->addWidget(this->miscComboBox[channel], channel * 3 + 1, 1);
+        this->dockLayout->addWidget(this->invertCheckBox[channel], channel * 3 + 2, 1);
     }
 
     this->dockWidget = new QWidget();
@@ -65,6 +68,7 @@ VoltageDock::VoltageDock(DsoSettings *settings, QWidget *parent, Qt::WindowFlags
     // Connect signals and slots
     for (int channel = 0; channel < settings->scope.voltage.count(); ++channel) {
         connect(this->gainComboBox[channel], SIGNAL(currentIndexChanged(int)), this, SLOT(gainSelected(int)));
+        connect(this->invertCheckBox[channel], SIGNAL(toggled(bool)), this, SLOT(invertSwitched(bool)));
         connect(this->miscComboBox[channel], SIGNAL(currentIndexChanged(int)), this, SLOT(miscSelected(int)));
         connect(this->usedCheckBox[channel], SIGNAL(toggled(bool)), this, SLOT(usedSwitched(bool)));
     }
@@ -190,5 +194,21 @@ void VoltageDock::usedSwitched(bool checked) {
     if (channel < settings->scope.voltage.count()) {
         settings->scope.voltage[channel].used = checked;
         emit usedChanged(channel, checked);
+    }
+}
+
+/// \brief Called when the invert checkbox is switched.
+/// \param checked The check-state of the checkbox.
+void VoltageDock::invertSwitched(bool checked) {
+    int channel;
+
+    // Which checkbox was it?
+    for (channel = 0; channel < settings->scope.voltage.count(); ++channel)
+        if (this->sender() == this->invertCheckBox[channel]) break;
+
+    // Send signal if it was one of the checkboxes
+    if (channel < settings->scope.voltage.count()) {
+        settings->scope.voltage[channel].inverted = checked;
+        // Should we emit an event here?
     }
 }

--- a/openhantek/src/docks/VoltageDock.h
+++ b/openhantek/src/docks/VoltageDock.h
@@ -39,6 +39,7 @@ class VoltageDock : public QDockWidget {
     QList<QCheckBox *> usedCheckBox; ///< Enable/disable a specific channel
     QList<QComboBox *> gainComboBox; ///< Select the vertical gain for the channels
     QList<QComboBox *> miscComboBox; ///< Select coupling for real and mode for math channels
+    QList<QCheckBox *> invertCheckBox; ///< Select if the channels should be displayed inverted
 
     DsoSettings *settings; ///< The settings provided by the parent class
 
@@ -51,6 +52,7 @@ class VoltageDock : public QDockWidget {
     void gainSelected(int index);
     void miscSelected(int index);
     void usedSwitched(bool checked);
+    void invertSwitched(bool checked);
 
   signals:
     void couplingChanged(unsigned int channel, Dso::Coupling coupling); ///< A coupling has been selected

--- a/openhantek/src/docks/VoltageDock.h
+++ b/openhantek/src/docks/VoltageDock.h
@@ -34,11 +34,11 @@ class VoltageDock : public QDockWidget {
   protected:
     void closeEvent(QCloseEvent *event);
 
-    QGridLayout *dockLayout;         ///< The main layout for the dock window
-    QWidget *dockWidget;             ///< The main widget for the dock window
-    QList<QCheckBox *> usedCheckBox; ///< Enable/disable a specific channel
-    QList<QComboBox *> gainComboBox; ///< Select the vertical gain for the channels
-    QList<QComboBox *> miscComboBox; ///< Select coupling for real and mode for math channels
+    QGridLayout *dockLayout;           ///< The main layout for the dock window
+    QWidget *dockWidget;               ///< The main widget for the dock window
+    QList<QCheckBox *> usedCheckBox;   ///< Enable/disable a specific channel
+    QList<QComboBox *> gainComboBox;   ///< Select the vertical gain for the channels
+    QList<QComboBox *> miscComboBox;   ///< Select coupling for real and mode for math channels
     QList<QCheckBox *> invertCheckBox; ///< Select if the channels should be displayed inverted
 
     DsoSettings *settings; ///< The settings provided by the parent class

--- a/openhantek/src/glgenerator.cpp
+++ b/openhantek/src/glgenerator.cpp
@@ -232,12 +232,13 @@ void GlGenerator::generateGraphs(const DataAnalyzerResult *result) {
                             result->data(channel)->voltage.sample.begin();
                         const double gain = settings->voltage[channel].gain;
                         const double offset = settings->voltage[channel].offset;
+                        const double invert = settings->voltage[channel].inverted ? -1.0 : 1.0;
 
                         std::advance(dataIterator, swTriggerStart - preTrigSamples);
 
                         for (unsigned int position = 0; position < sampleCount; ++position) {
                             *(glIterator++) = position * horizontalFactor - DIVS_TIME / 2;
-                            *(glIterator++) = *(dataIterator++) / gain + offset;
+                            *(glIterator++) = invert * (*(dataIterator++) / gain + offset);
                         }
                     } else {
                         std::vector<double>::const_iterator dataIterator =
@@ -292,10 +293,12 @@ void GlGenerator::generateGraphs(const DataAnalyzerResult *result) {
                 const double yGain = settings->voltage[yChannel].gain;
                 const double xOffset = settings->voltage[xChannel].offset;
                 const double yOffset = settings->voltage[yChannel].offset;
+                const double xInvert = settings->voltage[xChannel].inverted ? -1.0 : 1.0;
+                const double yInvert = settings->voltage[yChannel].inverted ? -1.0 : 1.0;
 
                 for (unsigned int position = 0; position < sampleCount; ++position) {
-                    *(glIterator++) = *(xIterator++) / xGain + xOffset;
-                    *(glIterator++) = *(yIterator++) / yGain + yOffset;
+                    *(glIterator++) = xInvert * (*(xIterator++) / xGain + xOffset);
+                    *(glIterator++) = yInvert * (*(yIterator++) / yGain + yOffset);
                 }
             } else {
                 // Delete all vector arrays

--- a/openhantek/src/scopesettings.h
+++ b/openhantek/src/scopesettings.h
@@ -45,6 +45,7 @@ struct DsoSettingsScopeSpectrum {
 struct DsoSettingsScopeVoltage {
     double gain;    ///< The vertical resolution in V/div
     int misc;       ///< Different enums, coupling for real- and mode for math-channels
+    bool inverted;  ///< true if the channel is inverted (mirrored on cross-axis)
     QString name;   ///< Name of this channel
     double offset;  ///< Vertical offset in divs
     double trigger; ///< Trigger level in V


### PR DESCRIPTION
Seems I cannot update or reopen my closed pull request (#67), so here we go, rebased onto current master. The clang-format changes are in a separate commit, which I can squash if you want (there were many other formatting changes, but I only included the one relevant for this pull request).

I currently cannot test the rebased changes as I don't have a scope with me and the new version won't let me start the program if there is no scope.