### PR TITLE
Fix settings loader, change LevelSlider needle shape

### DIFF
--- a/openhantek/src/dsowidget.cpp
+++ b/openhantek/src/dsowidget.cpp
@@ -217,6 +217,7 @@ DsoWidget::DsoWidget(DsoSettings *settings, QWidget *parent, Qt::WindowFlags fla
         mainScope->update();
         zoomScope->update();
     });
+    updateTriggerSource();
 }
 
 void DsoWidget::showNewData(std::unique_ptr<DataAnalyzerResult> data) {

--- a/openhantek/src/hantek/hantekdsocontrol.cpp
+++ b/openhantek/src/hantek/hantekdsocontrol.cpp
@@ -220,7 +220,6 @@ HantekDsoControl::HantekDsoControl(USBDevice *device) : device(device) {
         break;
 
     case MODEL_DSO5200A:
-        [[clang::fallthrough]];
     case MODEL_DSO5200:
         // Instantiate additional commands for the DSO-5200
         command[BULK_CSETTRIGGERORSAMPLERATE] = new BulkSetSamplerate5200();

--- a/openhantek/src/main.cpp
+++ b/openhantek/src/main.cpp
@@ -162,8 +162,7 @@ int main(int argc, char *argv[]) {
     QObject::connect(&dsoControl, &HantekDsoControl::samplesAvailable, &dataAnalyser, &DataAnalyzer::samplesAvailable);
 
     //////// Create settings object ////////
-    DsoSettings settings;
-    settings.setChannelCount(dsoControl.getChannelCount());
+    DsoSettings settings(dsoControl.getChannelCount());
     dataAnalyser.applySettings(&settings.scope);
 
     //////// Create main window ////////

--- a/openhantek/src/settings.cpp
+++ b/openhantek/src/settings.cpp
@@ -33,7 +33,10 @@
 
 /// \brief Set the number of channels.
 /// \param channels The new channel count, that will be applied to lists.
-DsoSettings::DsoSettings() { load(); }
+DsoSettings::DsoSettings(unsigned int channels) {
+    setChannelCount(channels);
+    load();
+}
 
 bool DsoSettings::setFilename(const QString &filename) {
     std::unique_ptr<QSettings> local = std::unique_ptr<QSettings>(new QSettings(filename, QSettings::IniFormat));

--- a/openhantek/src/settings.h
+++ b/openhantek/src/settings.h
@@ -23,7 +23,7 @@ struct DsoSettingsOptions {
 /// \brief Holds the settings of the program.
 class DsoSettings {
   public:
-    DsoSettings();
+    explicit DsoSettings(unsigned int channels);
     bool setFilename(const QString &filename);
 
     void setChannelCount(unsigned int channels);

--- a/openhantek/src/widgets/levelslider.cpp
+++ b/openhantek/src/widgets/levelslider.cpp
@@ -40,7 +40,7 @@ LevelSlider::LevelSlider(Qt::ArrowType direction, QWidget *parent) : QWidget(par
     this->setFont(font);
 
     this->pressedSlider = -1;
-    this->sliderWidth = 8;
+    this->sliderWidth = 12;
 
     this->setDirection(direction);
 }
@@ -381,44 +381,45 @@ void LevelSlider::paintEvent(QPaintEvent *event) {
         painter.setPen((*slider)->color);
 
         if ((*slider)->text.isEmpty()) {
-            int needlePoints[6];
+            QVector<QPoint> needlePoints;
+            QRect& sRect = (*slider)->rect;
+            const int W = this->sliderWidth;
 
             switch (this->_direction) {
             case Qt::LeftArrow:
-                needlePoints[0] = (*slider)->rect.left() + 4;
-                needlePoints[1] = (*slider)->rect.top();
-                needlePoints[2] = (*slider)->rect.left() + 1;
-                needlePoints[3] = (*slider)->rect.top() + 3;
-                needlePoints[4] = (*slider)->rect.left() + 4;
-                needlePoints[5] = (*slider)->rect.top() + 6;
+                needlePoints << QPoint(sRect.left() + 4, sRect.top()    )
+                             << QPoint(sRect.left() + 1, sRect.top() + 3)
+                             << QPoint(sRect.left() + 4, sRect.top() + 6)
+                             << QPoint(sRect.left() + W, sRect.top() + 6)
+                             << QPoint(sRect.left() + W, sRect.top()    );
                 break;
             case Qt::UpArrow:
-                needlePoints[0] = (*slider)->rect.left();
-                needlePoints[1] = (*slider)->rect.top() + 4;
-                needlePoints[2] = (*slider)->rect.left() + 3;
-                needlePoints[3] = (*slider)->rect.top() + 1;
-                needlePoints[4] = (*slider)->rect.left() + 6;
-                needlePoints[5] = (*slider)->rect.top() + 4;
+                needlePoints << QPoint(sRect.left(),     sRect.top() + 4)
+                             << QPoint(sRect.left() + 3, sRect.top() + 1)
+                             << QPoint(sRect.left() + 6, sRect.top() + 4)
+                             << QPoint(sRect.left() + 6, sRect.top() + W)
+                             << QPoint(sRect.left(),     sRect.top() + W);
                 break;
             case Qt::DownArrow:
-                needlePoints[0] = (*slider)->rect.left();
-                needlePoints[1] = (*slider)->rect.top() + this->sliderWidth - 5;
-                needlePoints[2] = (*slider)->rect.left() + 3;
-                needlePoints[3] = (*slider)->rect.top() + this->sliderWidth - 2;
-                needlePoints[4] = (*slider)->rect.left() + 6;
-                needlePoints[5] = (*slider)->rect.top() + this->sliderWidth - 5;
+                needlePoints << QPoint(sRect.left(),     sRect.top() + W - 5)
+                             << QPoint(sRect.left() + 3, sRect.top() + W - 2)
+                             << QPoint(sRect.left() + 6, sRect.top() + W - 5)
+                             << QPoint(sRect.left() + 6, sRect.top()        )
+                             << QPoint(sRect.left(),     sRect.top()        );
+                break;
+            case Qt::RightArrow:
+                needlePoints << QPoint(sRect.left() + W - 5, sRect.top()    )
+                             << QPoint(sRect.left() + W - 2, sRect.top() + 3)
+                             << QPoint(sRect.left() + W - 5, sRect.top() + 6)
+                             << QPoint(sRect.left(),         sRect.top() + 6)
+                             << QPoint(sRect.left(),         sRect.top()    );
                 break;
             default:
-                needlePoints[0] = (*slider)->rect.left() + this->sliderWidth - 5;
-                needlePoints[1] = (*slider)->rect.top();
-                needlePoints[2] = (*slider)->rect.left() + this->sliderWidth - 2;
-                needlePoints[3] = (*slider)->rect.top() + 3;
-                needlePoints[4] = (*slider)->rect.left() + this->sliderWidth - 5;
-                needlePoints[5] = (*slider)->rect.top() + 6;
+                break;
             }
 
             painter.setBrush(QBrush((*slider)->color, Qt::SolidPattern));
-            painter.drawPolygon(QPolygon(3, needlePoints));
+            painter.drawPolygon(QPolygon(needlePoints));
             painter.setBrush(Qt::NoBrush);
         } else {
             // Get rect for text and draw needle
@@ -539,8 +540,8 @@ QRect LevelSlider::calculateRect(int sliderId) {
 /// \brief Search for the widest slider element.
 /// \return The calculated width of the slider.
 int LevelSlider::calculateWidth() {
-    // At least 8 px for the needles
-    this->sliderWidth = 8;
+    // At least 12 px for the needles
+    this->sliderWidth = 12;
 
     // Is it a vertical slider?
     if (this->_direction == Qt::RightArrow || this->_direction == Qt::LeftArrow) {


### PR DESCRIPTION
@davidgraeff thanks for the great Xmas refactoring!

- The settings loader, however, overrides color settings with default values - the ctor calls **load()** before **setChannelCount()**. Now fixed.
- An extra minor enhancement is new shape of LevelSlider, see screenshot below. Simplifies dragging trigger level & position sliders.
- Finally, the PR eliminates g++ warning 
```
/home/travis/build/OpenHantek/openhantek/openhantek/src/hantek/hantekdsocontrol.cpp: In constructor ‘HantekDsoControl::HantekDsoControl(USBDevice*)’:
/home/travis/build/OpenHantek/openhantek/openhantek/src/hantek/hantekdsocontrol.cpp:223:9: warning: attributes at the beginning of statement are ignored [-Wattributes]
         [[clang::fallthrough]];
         ^
```
![screenshot](https://user-images.githubusercontent.com/11679699/34275807-f4aa834e-e6af-11e7-8145-1d983f823560.png)
