### PR TITLE
GUI maintenance

### DIFF
--- a/openhantek/src/analyse/dataanalyzer.cpp
+++ b/openhantek/src/analyse/dataanalyzer.cpp
@@ -23,7 +23,7 @@ std::unique_ptr<DataAnalyzerResult> DataAnalyzer::convertData(const DSOsamples *
     std::unique_ptr<DataAnalyzerResult> result =
         std::unique_ptr<DataAnalyzerResult>(new DataAnalyzerResult(channelCount));
 
-    for (unsigned int channel = 0; channel < channelCount; ++channel) {
+    for (ChannelID channel = 0; channel < channelCount; ++channel) {
         DataChannel *const channelData = result->modifyData(channel);
 
         bool gotDataForChannel = channel < physicalChannels && channel < (unsigned int)data->data.size() &&
@@ -123,7 +123,7 @@ void DataAnalyzer::spectrumAnalysis(DataAnalyzerResult *result, Dso::WindowFunct
                                     unsigned int lastRecordLength, double *&lastWindowBuffer,
                                     const DsoSettingsScope *scope) {
     // Calculate frequencies, peak-to-peak voltages and spectrums
-    for (unsigned int channel = 0; channel < result->channelCount(); ++channel) {
+    for (ChannelID channel = 0; channel < result->channelCount(); ++channel) {
         DataChannel *const channelData = result->modifyData(channel);
 
         if (channelData->voltage.sample.empty()) {

--- a/openhantek/src/analyse/dataanalyzer.h
+++ b/openhantek/src/analyse/dataanalyzer.h
@@ -16,8 +16,6 @@
 class DsoSettings;
 struct DsoSettingsScope;
 
-////////////////////////////////////////////////////////////////////////////////
-/// \class DataAnalyzer                                           dataanalyzer.h
 /// \brief Analyzes the data from the dso.
 /// Calculates the spectrum and various data about the signal and saves the
 /// time-/frequencysteps between two values.

--- a/openhantek/src/analyse/dataanalyzerresult.h
+++ b/openhantek/src/analyse/dataanalyzerresult.h
@@ -5,16 +5,12 @@
 #include <vector>
 #include "hantekprotocol/definitions.h"
 
-////////////////////////////////////////////////////////////////////////////////
-/// \struct SampleValues                                          dataanalyzer.h
 /// \brief Struct for a array of sample values.
 struct SampleValues {
     std::vector<double> sample; ///< Vector holding the sampling data
     double interval = 0.0;      ///< The interval between two sample values
 };
 
-////////////////////////////////////////////////////////////////////////////////
-/// \struct AnalyzedData                                          dataanalyzer.h
 /// \brief Struct for the analyzed data.
 struct DataChannel {
     SampleValues voltage;   ///< The time-domain voltage levels (V)
@@ -23,6 +19,7 @@ struct DataChannel {
     double frequency = 0.0; ///< The frequency of the signal
 };
 
+/// A result from the { @link DataAnalyzer } class.
 class DataAnalyzerResult {
   public:
     DataAnalyzerResult(unsigned int channelCount);

--- a/openhantek/src/docks/HorizontalDock.h
+++ b/openhantek/src/docks/HorizontalDock.h
@@ -6,7 +6,8 @@
 #include <QGridLayout>
 
 #include <vector>
-#include "settings.h"
+
+#include "hantekdso/enums.h"
 
 class QLabel;
 class QCheckBox;
@@ -14,7 +15,10 @@ class QComboBox;
 
 class SiSpinBox;
 
+struct DsoSettingsScope;
+
 Q_DECLARE_METATYPE(std::vector<unsigned>)
+Q_DECLARE_METATYPE(std::vector<double>)
 
 /// \brief Dock window for the horizontal axis.
 /// It contains the settings for the timebase and the display format.
@@ -22,13 +26,39 @@ class HorizontalDock : public QDockWidget {
     Q_OBJECT
 
   public:
-    HorizontalDock(DsoSettings *settings, QWidget *parent, Qt::WindowFlags flags = 0);
+    /// \brief Initializes the horizontal axis docking window.
+    /// \param settings The target settings object.
+    /// \param parent The parent widget.
+    /// \param flags Flags for the window manager.
+    HorizontalDock(DsoSettingsScope *scope, QWidget *parent, Qt::WindowFlags flags = 0);
 
+    /// \brief Changes the frequencybase.
+    /// \param frequencybase The frequencybase in hertz.
     void setFrequencybase(double timebase);
+    /// \brief Changes the samplerate.
+    /// \param samplerate The samplerate in seconds.
     void setSamplerate(double samplerate);
+    /// \brief Changes the timebase.
+    /// \param timebase The timebase in seconds.
     double setTimebase(double timebase);
+    /// \brief Changes the record length if the new value is supported.
+    /// \param recordLength The record length in samples.
     void setRecordLength(unsigned int recordLength);
+    /// \brief Changes the format if the new value is supported.
+    /// \param format The format for the horizontal axis.
+    /// \return Index of format-value, -1 on error.
     int setFormat(Dso::GraphFormat format);
+    /// \brief Updates the available record lengths in the combo box.
+    /// \param recordLengths The available record lengths for the combo box.
+    void setAvailableRecordLengths(const std::vector<unsigned> &recordLengths);
+    /// \brief Updates the minimum and maximum of the samplerate spin box.
+    /// \param minimum The minimum value the spin box should accept.
+    /// \param maximum The minimum value the spin box should accept.
+    void setSamplerateLimits(double minimum, double maximum);
+    /// \brief Updates the mode and steps of the samplerate spin box.
+    /// \param mode The mode value the spin box should accept.
+    /// \param steps The steps value the spin box should accept.
+    void setSamplerateSteps(int mode, QList<double> sampleSteps);
 
   protected:
     void closeEvent(QCloseEvent *event);
@@ -47,15 +77,10 @@ class HorizontalDock : public QDockWidget {
     QComboBox *formatComboBox;         ///< Selects the way the sampled data is
                                        /// interpreted and shown
 
-    DsoSettings *settings = nullptr; ///< The settings provided by the parent class
+    DsoSettingsScope *scope; ///< The settings provided by the parent class
     QList<double> timebaseSteps;     ///< Steps for the timebase spinbox
 
     QStringList formatStrings; ///< Strings for the formats
-
-  public slots:
-    void availableRecordLengthsChanged(const std::vector<unsigned> &recordLengths);
-    void samplerateLimitsChanged(double minimum, double maximum);
-    void samplerateSet(int mode, QList<double> sampleSteps);
 
   protected slots:
     void frequencybaseSelected(double frequencybase);

--- a/openhantek/src/docks/SpectrumDock.cpp
+++ b/openhantek/src/docks/SpectrumDock.cpp
@@ -5,6 +5,7 @@
 #include <QComboBox>
 #include <QDockWidget>
 #include <QLabel>
+#include <QSignalBlocker>
 
 #include <cmath>
 
@@ -16,43 +17,56 @@
 #include "utils/dsoStrings.h"
 #include "utils/printutils.h"
 
-////////////////////////////////////////////////////////////////////////////////
-// class SpectrumDock
-/// \brief Initializes the spectrum view docking window.
-/// \param settings The target settings object.
-/// \param parent The parent widget.
-/// \param flags Flags for the window manager.
-SpectrumDock::SpectrumDock(DsoSettings *settings, QWidget *parent, Qt::WindowFlags flags)
-    : QDockWidget(tr("Spectrum"), parent, flags), settings(settings) {
+template<typename... Args> struct SELECT {
+    template<typename C, typename R>
+    static constexpr auto OVERLOAD_OF( R (C::*pmf)(Args...) ) -> decltype(pmf) {
+        return pmf;
+    }
+};
+
+SpectrumDock::SpectrumDock(DsoSettingsScope *scope, QWidget *parent, Qt::WindowFlags flags)
+    : QDockWidget(tr("Spectrum"), parent, flags), scope(scope) {
 
     // Initialize lists for comboboxes
     this->magnitudeSteps = { 1e0 , 2e0 , 3e0 , 6e0 , 1e1 , 2e1 , 3e1 , 6e1 , 1e2 , 2e2 , 3e2, 6e2 };
     for (const auto& magnitude: magnitudeSteps)
         this->magnitudeStrings << valueToString(magnitude, UNIT_DECIBEL, 0);
 
-    // Initialize elements
-    for (ChannelID channel = 0; channel < settings->scope.voltage.size(); ++channel) {
-        this->magnitudeComboBox.push_back(new QComboBox());
-        this->magnitudeComboBox[channel]->addItems(this->magnitudeStrings);
-
-        this->usedCheckBox.push_back(new QCheckBox(settings->scope.voltage[channel].name));
-    }
-
     this->dockLayout = new QGridLayout();
     this->dockLayout->setColumnMinimumWidth(0, 64);
     this->dockLayout->setColumnStretch(1, 1);
-    for (ChannelID channel = 0; channel < settings->scope.voltage.size(); ++channel) {
-        this->dockLayout->addWidget(this->usedCheckBox[channel], (int)channel, 0);
-        this->dockLayout->addWidget(this->magnitudeComboBox[channel], (int)channel, 1);
+
+    // Initialize elements
+    for (ChannelID channel = 0; channel < scope->voltage.size(); ++channel) {
+        ChannelBlock b;
+        b.magnitudeComboBox=(new QComboBox());
+        b.usedCheckBox=(new QCheckBox(scope->voltage[channel].name));
+
+        channelBlocks.push_back(b);
+
+        this->dockLayout->addWidget(b.usedCheckBox, (int)channel, 0);
+        this->dockLayout->addWidget(b.magnitudeComboBox, (int)channel, 1);
+
+        b.magnitudeComboBox->addItems(this->magnitudeStrings);
+        this->setMagnitude(channel, scope->spectrum[channel].magnitude);
+        this->setUsed(channel, scope->spectrum[channel].used);
 
         // Connect signals and slots
-        connect(usedCheckBox[channel], &QCheckBox::toggled, this, &SpectrumDock::usedSwitched);
-        QComboBox* cmb = magnitudeComboBox[channel];
-        connect(cmb, static_cast<void (QComboBox::*)(int)>(&QComboBox::currentIndexChanged), this, &SpectrumDock::magnitudeSelected);
+        connect(b.usedCheckBox, &QCheckBox::toggled, [this,channel](bool checked) {
+            // Send signal if it was one of the checkboxes
+            if (channel < this->scope->voltage.size()) {
+                this->scope->spectrum[channel].used = checked;
+                emit usedChanged(channel, checked);
+            }
+        });
 
-        // Set values
-        this->setMagnitude(channel, settings->scope.spectrum[channel].magnitude);
-        this->setUsed(channel, settings->scope.spectrum[channel].used);
+        connect(b.magnitudeComboBox, SELECT<int>::OVERLOAD_OF(&QComboBox::currentIndexChanged), [this,channel](unsigned index) {
+            // Send signal if it was one of the comboboxes
+            if (channel < this->scope->voltage.size()) {
+                this->scope->spectrum[channel].magnitude = this->magnitudeSteps.at(index);
+                emit magnitudeChanged(channel, this->scope->spectrum[channel].magnitude);
+            }
+        });
     }
 
     dockWidget = new QWidget();
@@ -67,59 +81,21 @@ void SpectrumDock::closeEvent(QCloseEvent *event) {
     event->accept();
 }
 
-/// \brief Sets the magnitude for a channel.
-/// \param channel The channel, whose magnitude should be set.
-/// \param magnitude The magnitude in dB.
-/// \return Index of magnitude-value, -1 on error.
 int SpectrumDock::setMagnitude(ChannelID channel, double magnitude) {
-    if (channel >= settings->scope.voltage.size()) return -1;
+    if (channel >= scope->voltage.size()) return -1;
+    QSignalBlocker blocker(channelBlocks[channel].magnitudeComboBox);
 
     auto indexIt = std::find(magnitudeSteps.begin(),magnitudeSteps.end(),magnitude);
     if (indexIt == magnitudeSteps.end()) return -1;
     int index = (int)std::distance(magnitudeSteps.begin(), indexIt);
-    magnitudeComboBox[channel]->setCurrentIndex(index);
+    channelBlocks[channel].magnitudeComboBox->setCurrentIndex(index);
     return index;
 }
 
-/// \brief Enables/disables a channel.
-/// \param channel The channel, that should be enabled/disabled.
-/// \param used True if the channel should be enabled, false otherwise.
-/// \return Index of channel, INT_MAX on error.
 unsigned SpectrumDock::setUsed(ChannelID channel, bool used) {
-    if (channel >= settings->scope.voltage.size()) return INT_MAX;
+    if (channel >= scope->voltage.size()) return INT_MAX;
+    QSignalBlocker blocker(channelBlocks[channel].usedCheckBox);
 
-    this->usedCheckBox[channel]->setChecked(used);
+    channelBlocks[channel].usedCheckBox->setChecked(used);
     return channel;
-}
-
-/// \brief Called when the source combo box changes it's value.
-/// \param index The index of the combo box item.
-void SpectrumDock::magnitudeSelected(unsigned index) {
-    ChannelID channel;
-
-    // Which combobox was it?
-    for (channel = 0; channel < settings->scope.voltage.size(); ++channel)
-        if (this->sender() == this->magnitudeComboBox[channel]) break;
-
-    // Send signal if it was one of the comboboxes
-    if (channel < settings->scope.voltage.size()) {
-        settings->scope.spectrum[channel].magnitude = this->magnitudeSteps.at(index);
-        emit magnitudeChanged(channel, settings->scope.spectrum[channel].magnitude);
-    }
-}
-
-/// \brief Called when the used checkbox is switched.
-/// \param checked The check-state of the checkbox.
-void SpectrumDock::usedSwitched(bool checked) {
-    ChannelID channel;
-
-    // Which checkbox was it?
-    for (channel = 0; channel < settings->scope.voltage.size(); ++channel)
-        if (this->sender() == this->usedCheckBox[channel]) break;
-
-    // Send signal if it was one of the checkboxes
-    if (channel < settings->scope.voltage.size()) {
-        settings->scope.spectrum[channel].used = checked;
-        emit usedChanged(channel, checked);
-    }
 }

--- a/openhantek/src/docks/SpectrumDock.h
+++ b/openhantek/src/docks/SpectrumDock.h
@@ -5,7 +5,7 @@
 #include <QDockWidget>
 #include <QGridLayout>
 
-#include "settings.h"
+#include "scopesettings.h"
 
 class QLabel;
 class QCheckBox;
@@ -20,9 +20,22 @@ class SpectrumDock : public QDockWidget {
     Q_OBJECT
 
   public:
-    SpectrumDock(DsoSettings *settings, QWidget *parent, Qt::WindowFlags flags = 0);
+    /// \brief Initializes the spectrum view docking window.
+    /// \param settings The target settings object.
+    /// \param parent The parent widget.
+    /// \param flags Flags for the window manager.
+    SpectrumDock(DsoSettingsScope *scope, QWidget *parent, Qt::WindowFlags flags = 0);
 
+    /// \brief Sets the magnitude for a channel.
+    /// \param channel The channel, whose magnitude should be set.
+    /// \param magnitude The magnitude in dB.
+    /// \return Index of magnitude-value, -1 on error.
     int setMagnitude(ChannelID channel, double magnitude);
+
+    /// \brief Enables/disables a channel.
+    /// \param channel The channel, that should be enabled/disabled.
+    /// \param used True if the channel should be enabled, false otherwise.
+    /// \return Index of channel, INT_MAX on error.
     unsigned setUsed(ChannelID channel, bool used);
 
   protected:
@@ -30,17 +43,18 @@ class SpectrumDock : public QDockWidget {
 
     QGridLayout *dockLayout;              ///< The main layout for the dock window
     QWidget *dockWidget;                  ///< The main widget for the dock window
-    std::vector<QCheckBox *> usedCheckBox;      ///< Enable/disable spectrum for a channel
-    std::vector<QComboBox *> magnitudeComboBox; ///< Select the vertical magnitude for the spectrums
 
-    DsoSettings *settings; ///< The settings provided by the parent class
+    struct ChannelBlock {
+        QCheckBox * usedCheckBox;   ///< Enable/disable a specific channel
+        QComboBox * magnitudeComboBox;   ///< Select the vertical magnitude for the spectrums
+    };
+
+    std::vector<ChannelBlock> channelBlocks;
+
+    DsoSettingsScope* scope; ///< The settings provided by the parent class
 
     std::vector<double> magnitudeSteps; ///< The selectable magnitude steps in dB/div
     QStringList magnitudeStrings; ///< String representations for the magnitude steps
-
-  public slots:
-    void magnitudeSelected(unsigned index);
-    void usedSwitched(bool checked);
 
   signals:
     void magnitudeChanged(ChannelID channel, double magnitude); ///< A magnitude has been selected

--- a/openhantek/src/docks/TriggerDock.h
+++ b/openhantek/src/docks/TriggerDock.h
@@ -19,10 +19,24 @@ class TriggerDock : public QDockWidget {
     Q_OBJECT
 
   public:
+    /// \brief Initializes the trigger settings docking window.
+    /// \param settings The target settings object.
+    /// \param specialTriggers The names of the special trigger sources.
+    /// \param parent The parent widget.
+    /// \param flags Flags for the window manager.
     TriggerDock(DsoSettings *settings, const std::vector<std::string>& specialTriggers, QWidget *parent, Qt::WindowFlags flags = 0);
 
+    /// \brief Changes the trigger mode if the new mode is supported.
+    /// \param mode The trigger mode.
     void setMode(Dso::TriggerMode mode);
-    int setSource(bool special, unsigned int id);
+
+    /// \brief Changes the trigger source if the new source is supported.
+    /// \param special true for a special channel (EXT, ...) as trigger source.
+    /// \param id The number of the channel, that should be used as trigger.
+    void setSource(bool special, unsigned int id);
+
+    /// \brief Changes the trigger slope if the new slope is supported.
+    /// \param slope The trigger slope.
     void setSlope(Dso::Slope slope);
 
   protected:
@@ -43,11 +57,6 @@ class TriggerDock : public QDockWidget {
     QStringList sourceStandardStrings; ///< Strings for the standard trigger sources
     QStringList sourceSpecialStrings;  ///< Strings for the special trigger sources
     QStringList slopeStrings;          ///< Strings for the trigger slopes
-
-  protected slots:
-    void modeSelected(int index);
-    void slopeSelected(int index);
-    void sourceSelected(int index);
 
   signals:
     void modeChanged(Dso::TriggerMode);                ///< The trigger mode has been changed

--- a/openhantek/src/docks/VoltageDock.cpp
+++ b/openhantek/src/docks/VoltageDock.cpp
@@ -5,6 +5,7 @@
 #include <QComboBox>
 #include <QDockWidget>
 #include <QLabel>
+#include <QSignalBlocker>
 
 #include <cmath>
 
@@ -16,24 +17,25 @@
 #include "utils/dsoStrings.h"
 #include "utils/printutils.h"
 
-////////////////////////////////////////////////////////////////////////////////
-// class VoltageDock
-/// \brief Initializes the vertical axis docking window.
-/// \param settings The target settings object.
-/// \param parent The parent widget.
-/// \param flags Flags for the window manager.
-VoltageDock::VoltageDock(DsoSettings *settings, QWidget *parent, Qt::WindowFlags flags)
-    : QDockWidget(tr("Voltage"), parent, flags), settings(settings) {
+template<typename... Args> struct SELECT {
+    template<typename C, typename R>
+    static constexpr auto OVERLOAD_OF( R (C::*pmf)(Args...) ) -> decltype(pmf) {
+        return pmf;
+    }
+};
+
+VoltageDock::VoltageDock(DsoSettingsScope *scope, const Dso::ControlSpecification *spec, QWidget *parent, Qt::WindowFlags flags)
+    : QDockWidget(tr("Voltage"), parent, flags), scope(scope), spec(spec) {
 
     // Initialize lists for comboboxes
-    for (Dso::Coupling c: settings->deviceSpecification->couplings)
+    for (Dso::Coupling c: spec->couplings)
         couplingStrings.append(Dso::couplingString(c));
 
     for( auto e: Dso::MathModeEnum ) {
         modeStrings.append(Dso::mathModeString(e));
     }
 
-    for (double gainStep: settings->scope.gainSteps)
+    for (double gainStep: scope->gainSteps)
         gainStrings << valueToString(gainStep, UNIT_VOLTS, 0);
 
     dockLayout = new QGridLayout();
@@ -41,15 +43,17 @@ VoltageDock::VoltageDock(DsoSettings *settings, QWidget *parent, Qt::WindowFlags
     dockLayout->setColumnStretch(1, 1);
 
     // Initialize elements
-    for (ChannelID channel = 0; channel < settings->scope.voltage.size(); ++channel) {
+    for (ChannelID channel = 0; channel < scope->voltage.size(); ++channel) {
         ChannelBlock b;
 
         b.miscComboBox=(new QComboBox());
         b.gainComboBox=(new QComboBox());
         b.invertCheckBox=(new QCheckBox(tr("Invert")));
-        b.usedCheckBox=(new QCheckBox(settings->scope.voltage[channel].name));
+        b.usedCheckBox=(new QCheckBox(scope->voltage[channel].name));
 
-        if (channel < settings->deviceSpecification->channels)
+        channelBlocks.push_back(std::move(b));
+
+        if (channel < spec->channels)
             b.miscComboBox->addItems(couplingStrings);
         else
             b.miscComboBox->addItems(modeStrings);
@@ -61,35 +65,33 @@ VoltageDock::VoltageDock(DsoSettings *settings, QWidget *parent, Qt::WindowFlags
         dockLayout->addWidget(b.miscComboBox, (int)channel * 3 + 1, 1);
         dockLayout->addWidget(b.invertCheckBox, (int)channel * 3 + 2, 1);
 
-        connect(b.gainComboBox, static_cast<void (QComboBox::*)(int)>(&QComboBox::currentIndexChanged), [this,channel](int index) {
-            this->settings->scope.voltage[channel].gainStepIndex = (unsigned)index;
-            emit gainChanged(channel, this->settings->scope.gain(channel));
+        if (channel < spec->channels)
+            setCoupling(channel, scope->voltage[channel].couplingIndex);
+        else
+            setMode(scope->voltage[channel].math);
+        setGain(channel, scope->voltage[channel].gainStepIndex);
+        setUsed(channel, scope->voltage[channel].used);
+
+        connect(b.gainComboBox, SELECT<int>::OVERLOAD_OF(&QComboBox::currentIndexChanged), [this,channel](int index) {
+            this->scope->voltage[channel].gainStepIndex = (unsigned)index;
+            emit gainChanged(channel, this->scope->gain(channel));
         });
         connect(b.invertCheckBox, &QAbstractButton::toggled, [this,channel](bool checked) {
-            this->settings->scope.voltage[channel].inverted = checked;
+            this->scope->voltage[channel].inverted = checked;
         });
-        connect(b.miscComboBox, static_cast<void (QComboBox::*)(int)>(&QComboBox::currentIndexChanged), [this,channel](int index){
-            if (channel < this->settings->deviceSpecification->channels) {
-                this->settings->scope.voltage[channel].couplingIndex = (unsigned)index;
-                emit couplingChanged(channel, this->settings->coupling(channel));
+        connect(b.miscComboBox, SELECT<int>::OVERLOAD_OF(&QComboBox::currentIndexChanged), [this,channel,spec,scope](int index){
+            if (channel < spec->channels) {
+                this->scope->voltage[channel].couplingIndex = (unsigned)index;
+                emit couplingChanged(channel, scope->coupling(channel, spec));
             } else {
-                this->settings->scope.voltage[channel].math = (Dso::MathMode) index;
-                emit modeChanged(this->settings->scope.voltage[channel].math);
+                this->scope->voltage[channel].math = (Dso::MathMode) index;
+                emit modeChanged(this->scope->voltage[channel].math);
             }
         });
         connect(b.usedCheckBox, &QAbstractButton::toggled, [this,channel](bool checked) {
-            this->settings->scope.voltage[channel].used = checked;
+            this->scope->voltage[channel].used = checked;
             emit usedChanged(channel, checked);
         });
-
-        channelBlocks.push_back(std::move(b));
-
-        if (channel < settings->deviceSpecification->channels)
-            setCoupling(channel, settings->scope.voltage[channel].couplingIndex);
-        else
-            setMode(settings->scope.voltage[channel].math);
-        setGain(channel, settings->scope.voltage[channel].gainStepIndex);
-        setUsed(channel, settings->scope.voltage[channel].used);
     }
 
     dockWidget = new QWidget();
@@ -104,22 +106,26 @@ void VoltageDock::closeEvent(QCloseEvent *event) {
 }
 
 void VoltageDock::setCoupling(ChannelID channel, unsigned couplingIndex) {
-    if (channel >= settings->deviceSpecification->channels) return;
-    if (couplingIndex >= settings->deviceSpecification->couplings.size()) return;
+    if (channel >= spec->channels) return;
+    if (couplingIndex >= spec->couplings.size()) return;
+    QSignalBlocker blocker(channelBlocks[channel].miscComboBox);
     channelBlocks[channel].miscComboBox->setCurrentIndex((int)couplingIndex);
 }
 
 void VoltageDock::setGain(ChannelID channel, unsigned gainStepIndex) {
-    if (channel >= settings->scope.voltage.size()) return;
-    if (gainStepIndex >= settings->scope.gainSteps.size()) return;
+    if (channel >= scope->voltage.size()) return;
+    if (gainStepIndex >= scope->gainSteps.size()) return;
+    QSignalBlocker blocker(channelBlocks[channel].gainComboBox);
     channelBlocks[channel].gainComboBox->setCurrentIndex((unsigned)gainStepIndex);
 }
 
 void VoltageDock::setMode(Dso::MathMode mode) {
-    channelBlocks[settings->deviceSpecification->channels].miscComboBox->setCurrentIndex((int)mode);
+    QSignalBlocker blocker(channelBlocks[spec->channels].miscComboBox);
+    channelBlocks[spec->channels].miscComboBox->setCurrentIndex((int)mode);
 }
 
 void VoltageDock::setUsed(ChannelID channel, bool used) {
-    if (channel >= settings->scope.voltage.size()) return;
+    if (channel >= scope->voltage.size()) return;
+    QSignalBlocker blocker(channelBlocks[channel].usedCheckBox);
     channelBlocks[channel].usedCheckBox->setChecked(used);
 }

--- a/openhantek/src/docks/VoltageDock.h
+++ b/openhantek/src/docks/VoltageDock.h
@@ -8,7 +8,8 @@
 #include <QComboBox>
 #include <QLabel>
 
-#include "settings.h"
+#include "scopesettings.h"
+#include "hantekdso/controlspecification.h"
 
 class SiSpinBox;
 
@@ -19,7 +20,11 @@ class VoltageDock : public QDockWidget {
     Q_OBJECT
 
   public:
-    VoltageDock(DsoSettings *settings, QWidget *parent, Qt::WindowFlags flags = 0);
+    /// \brief Initializes the vertical axis docking window.
+    /// \param settings The target settings object.
+    /// \param parent The parent widget.
+    /// \param flags Flags for the window manager.
+    VoltageDock(DsoSettingsScope *scope, const Dso::ControlSpecification* spec, QWidget *parent, Qt::WindowFlags flags = 0);
 
     /// \brief Sets the coupling for a channel.
     /// \param channel The channel, whose coupling should be set.
@@ -55,15 +60,16 @@ class VoltageDock : public QDockWidget {
 
     std::vector<ChannelBlock> channelBlocks;
 
-    DsoSettings *settings; ///< The settings provided by the parent class
+    DsoSettingsScope *scope; ///< The settings provided by the parent class
+    const Dso::ControlSpecification *spec;
 
     QStringList couplingStrings; ///< The strings for the couplings
     QStringList modeStrings;     ///< The strings for the math mode
     QStringList gainStrings;     ///< String representations for the gain steps
 
   signals:
-    void couplingChanged(unsigned int channel, Dso::Coupling coupling); ///< A coupling has been selected
-    void gainChanged(unsigned int channel, double gain);                ///< A gain has been selected
+    void couplingChanged(ChannelID channel, Dso::Coupling coupling); ///< A coupling has been selected
+    void gainChanged(ChannelID channel, double gain);                ///< A gain has been selected
     void modeChanged(Dso::MathMode mode);              ///< The mode for the math channels has been changed
-    void usedChanged(unsigned int channel, bool used); ///< A channel has been enabled/disabled
+    void usedChanged(ChannelID channel, bool used); ///< A channel has been enabled/disabled
 };

--- a/openhantek/src/docks/dockwindows.cpp
+++ b/openhantek/src/docks/dockwindows.cpp
@@ -30,4 +30,5 @@ void registerDockMetaTypes() {
     qRegisterMetaType<Dso::WindowFunction>();
     qRegisterMetaType<Dso::InterpolationMode>();
     qRegisterMetaType<std::vector<unsigned> >();
+    qRegisterMetaType<std::vector<double> >();
 }

--- a/openhantek/src/dsowidget.h
+++ b/openhantek/src/dsowidget.h
@@ -5,15 +5,17 @@
 #include <QHBoxLayout>
 #include <QLabel>
 #include <QList>
+#include <QGridLayout>
 #include <memory>
 
 #include "exporter.h"
 #include "glscope.h"
 #include "levelslider.h"
+#include "hantekdso/controlspecification.h"
 
 class DataAnalyzer;
-class DsoSettings;
-class QGridLayout;
+struct DsoSettingsScope;
+struct DsoSettingsView;
 
 /// \class DsoWidget
 /// \brief The widget for the oszilloscope-screen
@@ -27,8 +29,9 @@ class DsoWidget : public QWidget {
     /// \param dataAnalyzer The data analyzer that should be used as data source.
     /// \param parent The parent widget.
     /// \param flags Flags for the window manager.
-    DsoWidget(DsoSettings *settings, QWidget *parent = 0, Qt::WindowFlags flags = 0);
+    DsoWidget(DsoSettingsScope* scope, DsoSettingsView* view, const Dso::ControlSpecification* spec, QWidget *parent = 0, Qt::WindowFlags flags = 0);
     void showNewData(std::unique_ptr<DataAnalyzerResult> data);
+    void setExporterForNextFrame(std::unique_ptr<Exporter> exporter);
 
   protected:
     void adaptTriggerLevelSlider(ChannelID channel);
@@ -68,7 +71,10 @@ class DsoWidget : public QWidget {
     std::vector<QLabel *> measurementAmplitudeLabel; ///< Amplitude of the signal (V)
     std::vector<QLabel *> measurementFrequencyLabel; ///< Frequency of the signal (Hz)
 
-    DsoSettings *settings;  ///< The settings provided by the main window
+    DsoSettingsScope* scope;
+    DsoSettingsView* view;
+    const Dso::ControlSpecification* spec;
+
     GlGenerator *generator; ///< The generator for the OpenGL vertex arrays
     GlScope *mainScope;     ///< The main scope screen
     GlScope *zoomScope;     ///< The optional magnified scope screen
@@ -87,21 +93,17 @@ class DsoWidget : public QWidget {
     void updateTriggerSource();
 
     // Spectrum
-    void updateSpectrumMagnitude(unsigned int channel);
-    void updateSpectrumUsed(unsigned int channel, bool used);
+    void updateSpectrumMagnitude(ChannelID channel);
+    void updateSpectrumUsed(ChannelID channel, bool used);
 
     // Vertical axis
-    void updateVoltageCoupling(unsigned int channel);
+    void updateVoltageCoupling(ChannelID channel);
     void updateMathMode();
-    void updateVoltageGain(unsigned int channel);
-    void updateVoltageUsed(unsigned int channel, bool used);
+    void updateVoltageGain(ChannelID channel);
+    void updateVoltageUsed(ChannelID channel, bool used);
 
     // Menus
     void updateRecordLength(unsigned long size);
-
-    // Export
-    void exportAs();
-    void print();
 
     // Scope control
     void updateZoom(bool enabled);
@@ -113,13 +115,13 @@ class DsoWidget : public QWidget {
     // Sliders
     void updateOffset(ChannelID channel, double value);
     void updateTriggerPosition(int index, double value);
-    void updateTriggerLevel(int channel, double value);
+    void updateTriggerLevel(ChannelID channel, double value);
     void updateMarker(int marker, double value);
 
   signals:
     // Sliders
-    void offsetChanged(unsigned int channel, double value);       ///< A graph offset has been changed
+    void offsetChanged(ChannelID channel, double value);       ///< A graph offset has been changed
     void triggerPositionChanged(double value);                    ///< The pretrigger has been changed
-    void triggerLevelChanged(unsigned int channel, double value); ///< A trigger level has been changed
+    void triggerLevelChanged(ChannelID channel, double value); ///< A trigger level has been changed
     void markerChanged(unsigned int marker, double value);        ///< A marker position has been changed
 };

--- a/openhantek/src/exporter.cpp
+++ b/openhantek/src/exporter.cpp
@@ -136,7 +136,7 @@ bool Exporter::exportSamples(const DataAnalyzerResult *result) {
         // Draw the measurement table
         stretchBase = (double)(paintDevice->width() - lineHeight * 6) / 10;
         int channelCount = 0;
-        for (int channel = settings->scope.voltage.size() - 1; channel >= 0; channel--) {
+        for (ChannelID channel = settings->scope.voltage.size() - 1; channel >= 0; channel--) {
             if ((settings->scope.voltage[channel].used || settings->scope.spectrum[channel].used) &&
                 result->data(channel)) {
                 ++channelCount;
@@ -148,7 +148,7 @@ bool Exporter::exportSamples(const DataAnalyzerResult *result) {
                 // Print coupling/math mode
                 if ((unsigned int)channel < settings->deviceSpecification->channels)
                     painter.drawText(QRectF(lineHeight * 4, top, lineHeight * 2, lineHeight),
-                                     Dso::couplingString(settings->coupling(channel)));
+                                     Dso::couplingString(settings->scope.coupling(channel, settings->deviceSpecification)));
                 else
                     painter.drawText(QRectF(lineHeight * 4, top, lineHeight * 2, lineHeight),
                                      Dso::mathModeString(settings->scope.voltage[channel].math));
@@ -335,7 +335,7 @@ bool Exporter::exportCVS(const DataAnalyzerResult *result) {
 
     QTextStream csvStream(&csvFile);
 
-    int chCount = settings->scope.voltage.size();
+    size_t chCount = settings->scope.voltage.size();
     std::vector<const SampleValues *> voltageData(size_t(chCount), nullptr);
     std::vector<const SampleValues *> spectrumData(size_t(chCount), nullptr);
     size_t maxRow = 0;
@@ -343,7 +343,7 @@ bool Exporter::exportCVS(const DataAnalyzerResult *result) {
     double timeInterval = 0;
     double freqInterval = 0;
 
-    for (int channel = 0; channel < chCount; ++channel) {
+    for (ChannelID channel = 0; channel < chCount; ++channel) {
         if (result->data(channel)) {
             if (settings->scope.voltage[channel].used) {
                 voltageData[channel] = &(result->data(channel)->voltage);
@@ -361,12 +361,12 @@ bool Exporter::exportCVS(const DataAnalyzerResult *result) {
 
     // Start with channel names
     csvStream << "\"t\"";
-    for (int channel = 0; channel < chCount; ++channel) {
+    for (ChannelID channel = 0; channel < chCount; ++channel) {
         if (voltageData[channel] != nullptr) { csvStream << ",\"" << settings->scope.voltage[channel].name << "\""; }
     }
     if (isSpectrumUsed) {
         csvStream << ",\"f\"";
-        for (int channel = 0; channel < chCount; ++channel) {
+        for (ChannelID channel = 0; channel < chCount; ++channel) {
             if (spectrumData[channel] != nullptr) {
                 csvStream << ",\"" << settings->scope.spectrum[channel].name << "\"";
             }
@@ -377,7 +377,7 @@ bool Exporter::exportCVS(const DataAnalyzerResult *result) {
     for (unsigned int row = 0; row < maxRow; ++row) {
 
         csvStream << timeInterval * row;
-        for (int channel = 0; channel < chCount; ++channel) {
+        for (ChannelID channel = 0; channel < chCount; ++channel) {
             if (voltageData[channel] != nullptr) {
                 csvStream << ",";
                 if (row < voltageData[channel]->sample.size()) { csvStream << voltageData[channel]->sample[row]; }
@@ -386,7 +386,7 @@ bool Exporter::exportCVS(const DataAnalyzerResult *result) {
 
         if (isSpectrumUsed) {
             csvStream << "," << freqInterval * row;
-            for (int channel = 0; channel < chCount; ++channel) {
+            for (ChannelID channel = 0; channel < chCount; ++channel) {
                 if (spectrumData[channel] != nullptr) {
                     csvStream << ",";
                     if (row < spectrumData[channel]->sample.size()) { csvStream << spectrumData[channel]->sample[row]; }

--- a/openhantek/src/glgenerator.cpp
+++ b/openhantek/src/glgenerator.cpp
@@ -129,7 +129,7 @@ bool GlGenerator::generateGraphs(const DataAnalyzerResult *result, unsigned digi
         // Resize to the number of channels
         d.resize(scope->voltage.size());
 
-        for (unsigned int channel = 0; channel < vaChannel[(unsigned)mode].size(); ++channel) {
+        for (ChannelID channel = 0; channel < vaChannel[(unsigned)mode].size(); ++channel) {
             DrawLinesWithHistory& drawLinesHistory = d[channel];
             // Move the last list element to the front
             if (digitalPhosphorDepth > 1 && drawLinesHistory.size())

--- a/openhantek/src/glscope.h
+++ b/openhantek/src/glscope.h
@@ -18,21 +18,23 @@ using GL_WIDGET_CLASS = QGLWidget;
 #include "hantekprotocol/definitions.h"
 
 class GlGenerator;
-class DsoSettings;
+struct DsoSettingsScope;
+struct DsoSettingsView;
 
 /// \brief OpenGL accelerated widget that displays the oscilloscope screen.
 class GlScope : public GL_WIDGET_CLASS {
     Q_OBJECT
 
   public:
+    static GlScope* createNormal(DsoSettingsScope *scope, DsoSettingsView *view, const GlGenerator *generator, QWidget *parent = 0);
+    static GlScope* createZoomed(DsoSettingsScope *scope, DsoSettingsView *view, const GlGenerator *generator, QWidget *parent = 0);
+
+  protected:
     /// \brief Initializes the scope widget.
     /// \param settings The settings that should be used.
     /// \param parent The parent widget.
-    GlScope(DsoSettings *settings, const GlGenerator *generator, QWidget *parent = 0);
+    GlScope(DsoSettingsScope *scope, DsoSettingsView *view, const GlGenerator *generator, QWidget *parent = 0);
 
-    void setZoomMode(bool zoomEnabled);
-
-  protected:
     /// \brief Initializes OpenGL output.
     void initializeGL() override;
 
@@ -58,7 +60,8 @@ class GlScope : public GL_WIDGET_CLASS {
     bool channelUsed(Dso::ChannelMode mode, ChannelID channel);
 
   private:
-    DsoSettings *settings;
+    DsoSettingsScope *scope;
+    DsoSettingsView *view;
     const GlGenerator *generator;
     std::vector<int> fadingFactor;
 

--- a/openhantek/src/hantekdso/controlsettings.h
+++ b/openhantek/src/hantekdso/controlsettings.h
@@ -2,6 +2,7 @@
 
 #include "controlspecification.h"
 #include "enums.h"
+#include "softwaretriggersettings.h"
 
 namespace Dso {
 
@@ -59,7 +60,6 @@ struct ControlSettings {
     ControlSettingsTrigger trigger;              ///< The trigger settings
     RecordLengthID recordLengthId = 1;           ///< The id in the record length array
     unsigned usedChannels = 0;                   ///< Number of activated channels
-    // Software trigger, margin
-    const unsigned swtriggerSampleMargin = 2000;
+    SoftwareTriggerSettings swTrigger;
 };
 }

--- a/openhantek/src/hantekdso/hantekdsocontrol.cpp
+++ b/openhantek/src/hantekdso/hantekdsocontrol.cpp
@@ -659,7 +659,7 @@ Dso::ErrorCode HantekDsoControl::setSamplerate(double samplerate) {
 
         // Check for Roll mode
         if (!isRollMode())
-            emit recordTimeChanged((double)(getRecordLength() - controlsettings.swtriggerSampleMargin) /
+            emit recordTimeChanged((double)(getRecordLength() - controlsettings.swTrigger.sampleMargin) /
                                    controlsettings.samplerate.current);
         emit samplerateChanged(controlsettings.samplerate.current);
 
@@ -709,7 +709,7 @@ Dso::ErrorCode HantekDsoControl::setRecordTime(double duration) {
         unsigned sampleId;
         for (sampleId = 0; sampleId < specification.fixedSampleRates.size(); ++sampleId) {
             if (specification.fixedSampleRates[sampleId].samplerate * duration <
-                (sampleCount - controlsettings.swtriggerSampleMargin))
+                (sampleCount - controlsettings.swTrigger.sampleMargin))
                 break;
         }
         // Usable sample value

--- a/openhantek/src/hantekdso/softwaretrigger.cpp
+++ b/openhantek/src/hantekdso/softwaretrigger.cpp
@@ -11,7 +11,7 @@ SoftwareTrigger::PrePostStartTriggerSamples SoftwareTrigger::computeTY(const Dat
     unsigned int preTrigSamples = 0;
     unsigned int postTrigSamples = 0;
     unsigned int swTriggerStart = 0;
-    unsigned int channel = scope->trigger.source;
+    ChannelID channel = scope->trigger.source;
 
     // check trigger point for software trigger
     if (scope->trigger.mode != Dso::TriggerMode::SOFTWARE || channel >= physicalChannels)

--- a/openhantek/src/hantekdso/softwaretrigger.h
+++ b/openhantek/src/hantekdso/softwaretrigger.h
@@ -1,5 +1,6 @@
 #pragma once
 #include <tuple>
+#include "softwaretriggersettings.h"
 struct DsoSettingsScope;
 class DataAnalyzerResult;
 

--- a/openhantek/src/hantekdso/softwaretriggersettings.h
+++ b/openhantek/src/hantekdso/softwaretriggersettings.h
@@ -1,0 +1,5 @@
+#pragma once
+
+struct SoftwareTriggerSettings {
+    const unsigned sampleMargin = 2000;
+};

--- a/openhantek/src/hantekprotocol/bulkStructs.cpp
+++ b/openhantek/src/hantekprotocol/bulkStructs.cpp
@@ -26,7 +26,7 @@ BulkSetFilter::BulkSetFilter(bool channel1, bool channel2, bool trigger) : BulkC
 /// \brief Gets the filtering state of one channel.
 /// \param channel The channel whose filtering state should be returned.
 /// \return The filtering state of the channel.
-bool BulkSetFilter::getChannel(unsigned int channel) {
+bool BulkSetFilter::getChannel(ChannelID channel) {
     FilterBits *filterBits = (FilterBits *)&(this->array[2]);
     if (channel == 0)
         return filterBits->channel1 == 1;
@@ -37,7 +37,7 @@ bool BulkSetFilter::getChannel(unsigned int channel) {
 /// \brief Enables/disables filtering of one channel.
 /// \param channel The channel that should be set.
 /// \param filtered true if the channel should be filtered.
-void BulkSetFilter::setChannel(unsigned int channel, bool filtered) {
+void BulkSetFilter::setChannel(ChannelID channel, bool filtered) {
     FilterBits *filterBits = (FilterBits *)&(this->array[2]);
     if (channel == 0)
         filterBits->channel1 = filtered ? 1 : 0;
@@ -256,7 +256,7 @@ BulkSetGain::BulkSetGain(uint8_t channel1, uint8_t channel2) : BulkCommand(8) {
 /// \brief Get the gain for the given channel.
 /// \param channel The channel whose gain should be returned.
 /// \returns The gain value.
-uint8_t BulkSetGain::getGain(unsigned int channel) {
+uint8_t BulkSetGain::getGain(ChannelID channel) {
     GainBits *gainBits = (GainBits *)&(this->array[2]);
     if (channel == 0)
         return gainBits->channel1;
@@ -267,7 +267,7 @@ uint8_t BulkSetGain::getGain(unsigned int channel) {
 /// \brief Set the gain for the given channel.
 /// \param channel The channel that should be set.
 /// \param value The new gain value for the channel.
-void BulkSetGain::setGain(unsigned int channel, uint8_t value) {
+void BulkSetGain::setGain(ChannelID channel, uint8_t value) {
     GainBits *gainBits = (GainBits *)&(this->array[2]);
     if (channel == 0)
         gainBits->channel1 = value;

--- a/openhantek/src/hantekprotocol/bulkStructs.h
+++ b/openhantek/src/hantekprotocol/bulkStructs.h
@@ -29,8 +29,8 @@ class BulkSetFilter : public BulkCommand {
     BulkSetFilter();
     BulkSetFilter(bool channel1, bool channel2, bool trigger);
 
-    bool getChannel(unsigned int channel);
-    void setChannel(unsigned int channel, bool filtered);
+    bool getChannel(ChannelID channel);
+    void setChannel(ChannelID channel, bool filtered);
     bool getTrigger();
     void setTrigger(bool filtered);
 
@@ -130,8 +130,8 @@ class BulkSetGain : public BulkCommand {
     BulkSetGain();
     BulkSetGain(uint8_t channel1, uint8_t channel2);
 
-    uint8_t getGain(unsigned int channel);
-    void setGain(unsigned int channel, uint8_t value);
+    uint8_t getGain(ChannelID channel);
+    void setGain(ChannelID channel, uint8_t value);
 
   private:
     void init();

--- a/openhantek/src/hantekprotocol/controlStructs.cpp
+++ b/openhantek/src/hantekprotocol/controlStructs.cpp
@@ -14,14 +14,14 @@ ControlSetOffset::ControlSetOffset(uint16_t channel1, uint16_t channel2, uint16_
     this->setTrigger(trigger);
 }
 
-uint16_t ControlSetOffset::getChannel(unsigned int channel) {
+uint16_t ControlSetOffset::getChannel(ChannelID channel) {
     if (channel == 0)
         return ((this->array[0] & 0x0f) << 8) | this->array[1];
     else
         return ((this->array[2] & 0x0f) << 8) | this->array[3];
 }
 
-void ControlSetOffset::setChannel(unsigned int channel, uint16_t offset) {
+void ControlSetOffset::setChannel(ChannelID channel, uint16_t offset) {
     if (channel == 0) {
         this->array[0] = (uint8_t)(offset >> 8);
         this->array[1] = (uint8_t)offset;
@@ -50,42 +50,42 @@ ControlSetRelays::ControlSetRelays(bool ch1Below1V, bool ch1Below100mV, bool ch1
     this->setTrigger(triggerExt);
 }
 
-bool ControlSetRelays::getBelow1V(unsigned int channel) {
+bool ControlSetRelays::getBelow1V(ChannelID channel) {
     if (channel == 0)
         return (this->array[1] & 0x04) == 0x00;
     else
         return (this->array[4] & 0x20) == 0x00;
 }
 
-void ControlSetRelays::setBelow1V(unsigned int channel, bool below) {
+void ControlSetRelays::setBelow1V(ChannelID channel, bool below) {
     if (channel == 0)
         this->array[1] = below ? 0xfb : 0x04;
     else
         this->array[4] = below ? 0xdf : 0x20;
 }
 
-bool ControlSetRelays::getBelow100mV(unsigned int channel) {
+bool ControlSetRelays::getBelow100mV(ChannelID channel) {
     if (channel == 0)
         return (this->array[2] & 0x08) == 0x00;
     else
         return (this->array[5] & 0x40) == 0x00;
 }
 
-void ControlSetRelays::setBelow100mV(unsigned int channel, bool below) {
+void ControlSetRelays::setBelow100mV(ChannelID channel, bool below) {
     if (channel == 0)
         this->array[2] = below ? 0xf7 : 0x08;
     else
         this->array[5] = below ? 0xbf : 0x40;
 }
 
-bool ControlSetRelays::getCoupling(unsigned int channel) {
+bool ControlSetRelays::getCoupling(ChannelID channel) {
     if (channel == 0)
         return (this->array[3] & 0x02) == 0x00;
     else
         return (this->array[6] & 0x10) == 0x00;
 }
 
-void ControlSetRelays::setCoupling(unsigned int channel, bool dc) {
+void ControlSetRelays::setCoupling(ChannelID channel, bool dc) {
     if (channel == 0)
         this->array[3] = dc ? 0xfd : 0x02;
     else

--- a/openhantek/src/hantekprotocol/controlStructs.h
+++ b/openhantek/src/hantekprotocol/controlStructs.h
@@ -26,11 +26,11 @@ struct ControlSetOffset : public ControlCommand {
     /// \brief Get the offset for the given channel.
     /// \param channel The channel whose offset should be returned.
     /// \return The channel offset value.
-    uint16_t getChannel(unsigned int channel);
+    uint16_t getChannel(ChannelID channel);
     /// \brief Set the offset for the given channel.
     /// \param channel The channel that should be set.
     /// \param offset The new channel offset value.
-    void setChannel(unsigned int channel, uint16_t offset);
+    void setChannel(ChannelID channel, uint16_t offset);
     /// \brief Get the trigger level.
     /// \return The trigger level value.
     uint16_t getTrigger();
@@ -55,27 +55,27 @@ struct ControlSetRelays : public ControlCommand {
     /// \brief Get the below 1 V relay state for the given channel.
     /// \param channel The channel whose relay state should be returned.
     /// \return true, if the gain of the channel is below 1 V.
-    bool getBelow1V(unsigned int channel);
+    bool getBelow1V(ChannelID channel);
     /// \brief Set the below 1 V relay for the given channel.
     /// \param channel The channel that should be set.
     /// \param below true, if the gain of the channel should be below 1 V.
-    void setBelow1V(unsigned int channel, bool below);
+    void setBelow1V(ChannelID channel, bool below);
     /// \brief Get the below 1 V relay state for the given channel.
     /// \param channel The channel whose relay state should be returned.
     /// \return true, if the gain of the channel is below 1 V.
-    bool getBelow100mV(unsigned int channel);
+    bool getBelow100mV(ChannelID channel);
     /// \brief Set the below 100 mV relay for the given channel.
     /// \param channel The channel that should be set.
     /// \param below true, if the gain of the channel should be below 100 mV.
-    void setBelow100mV(unsigned int channel, bool below);
+    void setBelow100mV(ChannelID channel, bool below);
     /// \brief Get the coupling relay state for the given channel.
     /// \param channel The channel whose relay state should be returned.
     /// \return true, if the coupling of the channel is DC.
-    bool getCoupling(unsigned int channel);
+    bool getCoupling(ChannelID channel);
     /// \brief Set the coupling relay for the given channel.
     /// \param channel The channel that should be set.
     /// \param dc true, if the coupling of the channel should be DC.
-    void setCoupling(unsigned int channel, bool dc);
+    void setCoupling(ChannelID channel, bool dc);
     /// \brief Get the external trigger relay state.
     /// \return true, if the trigger is external (EXT-Connector).
     bool getTrigger();

--- a/openhantek/src/hantekprotocol/definitions.h
+++ b/openhantek/src/hantekprotocol/definitions.h
@@ -28,30 +28,6 @@ enum class UsedChannels : uint8_t {
     BUSED_CH2 = USED_NONE
 };
 
-
-/// \enum TriggerSource
-/// \brief The possible trigger sources.
-// enum TriggerSource { TRIGGER_CH2, TRIGGER_CH1, TRIGGER_ALT, TRIGGER_EXT, TRIGGER_EXT10 };
-
-
-/// \enum RecordLengthId
-/// \brief The size id for CommandSetTriggerAndSamplerate.
-//enum RecordLengthId {
-//    RECORDLENGTHID_ROLL = 0, ///< Used for the roll mode
-//    RECORDLENGTHID_SMALL,    ///< The standard buffer with 10240 samples
-//    RECORDLENGTHID_LARGE     ///< The large buffer, 32768 samples (14336 for DSO-5200)
-//};
-
-
-/// \enum LevelOffset
-/// \brief The array indicies for the CalibrationData.
-enum LevelOffset {
-    OFFSET_START, ///< The channel level at the bottom of the scope
-    OFFSET_END,   ///< The channel level at the top of the scope
-    OFFSET_COUNT
-};
-
-
 /// \enum DTriggerPositionUsed                                  hantek/types.h
 /// \brief The trigger position states for the 0x0d command.
 enum class DTriggerPositionUsed: uint8_t {

--- a/openhantek/src/mainwindow.cpp
+++ b/openhantek/src/mainwindow.cpp
@@ -1,25 +1,12 @@
-// SPDX-License-Identifier: GPL-2.0+
-
-#include <QAction>
-#include <QActionGroup>
-#include <QApplication>
-#include <QDir>
-#include <QFileDialog>
-#include <QLineEdit>
-#include <QMainWindow>
-#include <QMenu>
-#include <QMenuBar>
-#include <QMessageBox>
-#include <QStatusBar>
-#include <QToolBar>
-
 #include "mainwindow.h"
+#include "ui_mainwindow.h"
 
 #include "HorizontalDock.h"
 #include "SpectrumDock.h"
 #include "TriggerDock.h"
 #include "VoltageDock.h"
 #include "dockwindows.h"
+#include "exporter.h"
 
 #include "configdialog.h"
 #include "analyse/dataanalyzer.h"
@@ -30,14 +17,15 @@
 #include "dsomodel.h"
 #include "viewconstants.h"
 
-////////////////////////////////////////////////////////////////////////////////
-// class OpenHantekMainWindow
-/// \brief Initializes the gui elements of the main window.
-/// \param parent The parent widget.
-/// \param flags Flags for the window manager.
-OpenHantekMainWindow::OpenHantekMainWindow(HantekDsoControl *dsoControl, DataAnalyzer *dataAnalyzer,
-                                           DsoSettings *settings)
-    : dsoControl(dsoControl), dataAnalyzer(dataAnalyzer), settings(settings) {
+#include <QFileDialog>
+#include <QLineEdit>
+#include <QMessageBox>
+
+MainWindow::MainWindow(HantekDsoControl *dsoControl, DataAnalyzer *dataAnalyser, DsoSettings *settings, QWidget *parent) :
+    QMainWindow(parent), ui(new Ui::MainWindow), dsoControl(dsoControl), dataAnalyzer(dataAnalyser), settings(settings)
+{
+    ui->setupUi(this);
+
 
     // Window title
     setWindowIcon(QIcon(":openhantek.png"));
@@ -47,250 +35,84 @@ OpenHantekMainWindow::OpenHantekMainWindow(HantekDsoControl *dsoControl, DataAna
 #if (QT_VERSION >= QT_VERSION_CHECK(5, 6, 0))
     setDockOptions(dockOptions() | QMainWindow::GroupedDragging);
 #endif
-    createDockWindows();
+
+    registerDockMetaTypes();
+    horizontalDock = new HorizontalDock(&settings->scope, this);
+    triggerDock = new TriggerDock(settings, dsoControl->getSpecialTriggerSources(), this);
+    spectrumDock = new SpectrumDock(&settings->scope, this);
+    voltageDock = new VoltageDock(&settings->scope, settings->deviceSpecification, this);
 
     // Central oszilloscope widget
-    dsoWidget = new DsoWidget(settings);
+    dsoWidget = new DsoWidget(&settings->scope, &settings->view, settings->deviceSpecification);
     connect(dataAnalyzer, &DataAnalyzer::analyzed,
             [this]() { dsoWidget->showNewData(this->dataAnalyzer->getNextResult()); });
     setCentralWidget(dsoWidget);
 
-    // Subroutines for window elements
-    createActions();
-    createToolBars();
-    createMenus();
-    statusBar()->showMessage(tr("Ready"));
+    addDockWidget(Qt::RightDockWidgetArea, horizontalDock);
+    addDockWidget(Qt::RightDockWidgetArea, triggerDock);
+    addDockWidget(Qt::RightDockWidgetArea, voltageDock);
+    addDockWidget(Qt::RightDockWidgetArea, spectrumDock);
 
-#ifdef DEBUG
-    addManualCommandEdit();
-#endif
+    restoreGeometry(settings->mainWindowGeometry);
+    restoreState(settings->mainWindowState);
 
-    // Apply the settings after the gui is initialized
-    applySettings();
-
-    // Connect all signals
-    connectSignals();
-
-    // Set up the oscilloscope
-    applySettingsToDevice();
-}
-
-/// \brief Save the settings before exiting.
-/// \param event The close event that should be handled.
-void OpenHantekMainWindow::closeEvent(QCloseEvent *event) {
-    if (settings->options.alwaysSave) {
-        saveWindowGeometry();
-        settings->save();
-    }
-
-    QMainWindow::closeEvent(event);
-}
-
-/// \brief Create the used actions.
-void OpenHantekMainWindow::createActions() {
-    openAction = new QAction(QIcon(":actions/open.png"), tr("&Open..."), this);
-    openAction->setShortcut(tr("Ctrl+O"));
-    openAction->setStatusTip(tr("Open saved settings"));
-    connect(openAction, &QAction::triggered, [this]() {
-        QString fileName = QFileDialog::getOpenFileName(this, tr("Open file"), "", tr("Settings (*.ini)"));
-        if (!fileName.isEmpty()) {
-            if (settings->setFilename(fileName)) {
-                settings->load();
-                emit(settingsChanged());
-            }
-        }
-    });
-
-    saveAction = new QAction(QIcon(":actions/save.png"), tr("&Save"), this);
-    saveAction->setShortcut(tr("Ctrl+S"));
-    saveAction->setStatusTip(tr("Save the current settings"));
-    connect(saveAction, &QAction::triggered, [this]() {
-        saveWindowGeometry();
-        settings->save();
-    });
-
-    saveAsAction = new QAction(QIcon(":actions/save-as.png"), tr("Save &as..."), this);
-    saveAsAction->setStatusTip(tr("Save the current settings to another file"));
-    connect(saveAsAction, &QAction::triggered, [this]() {
-        QString fileName = QFileDialog::getSaveFileName(this, tr("Save settings"), "", tr("Settings (*.ini)"));
-        if (fileName.isEmpty()) return;
-        saveWindowGeometry();
-        settings->setFilename(fileName);
-        settings->save();
-    });
-
-    printAction = new QAction(QIcon(":actions/print.png"), tr("&Print..."), this);
-    printAction->setShortcut(tr("Ctrl+P"));
-    printAction->setStatusTip(tr("Print the oscilloscope screen"));
-    connect(printAction, &QAction::triggered, dsoWidget, &DsoWidget::print);
-
-    exportAsAction = new QAction(QIcon(":actions/export-as.png"), tr("&Export as..."), this);
-    exportAsAction->setShortcut(tr("Ctrl+E"));
-    exportAsAction->setStatusTip(tr("Export the oscilloscope data to a file"));
-    connect(exportAsAction, &QAction::triggered, dsoWidget, &DsoWidget::exportAs);
-
-    exitAction = new QAction(tr("E&xit"), this);
-    exitAction->setShortcut(tr("Ctrl+Q"));
-    exitAction->setStatusTip(tr("Exit the application"));
-    connect(exitAction, &QAction::triggered, this, &QWidget::close);
-
-    configAction = new QAction(tr("&Settings"), this);
-    configAction->setShortcut(tr("Ctrl+S"));
-    configAction->setStatusTip(tr("Configure the oscilloscope"));
-    connect(configAction, &QAction::triggered, [this]() {
-        saveWindowGeometry();
-
-        DsoConfigDialog configDialog(settings, this);
-        if (configDialog.exec() == QDialog::Accepted) settingsChanged();
-    });
-
-    startStopAction = new QAction(this);
-    startStopAction->setShortcut(tr("Space"));
-    stopped();
-
-    digitalPhosphorAction = new QAction(QIcon(":actions/digitalphosphor.png"), tr("Digital &phosphor"), this);
-    digitalPhosphorAction->setCheckable(true);
-    digitalPhosphorAction->setChecked(settings->view.digitalPhosphor);
-    digitalPhosphor(settings->view.digitalPhosphor);
-    connect(digitalPhosphorAction, &QAction::toggled, this, &OpenHantekMainWindow::digitalPhosphor);
-
-    zoomAction = new QAction(QIcon(":actions/zoom.png"), tr("&Zoom"), this);
-    zoomAction->setCheckable(true);
-    zoomAction->setChecked(settings->view.zoom);
-    zoom(settings->view.zoom);
-    connect(zoomAction, &QAction::toggled, this, &OpenHantekMainWindow::zoom);
-    connect(zoomAction, &QAction::toggled, dsoWidget, &DsoWidget::updateZoom);
-
-    aboutAction = new QAction(tr("&About"), this);
-    aboutAction->setStatusTip(tr("Show information about this program"));
-    connect(aboutAction, &QAction::triggered, [this]() {
-        QMessageBox::about(
-            this, tr("About OpenHantek %1").arg(VERSION),
-            tr("<p>This is a open source software for Hantek USB oscilloscopes.</p>"
-               "<p>Copyright &copy; 2010, 2011 Oliver Haag<br><a "
-               "href='mailto:oliver.haag@gmail.com'>oliver.haag@gmail.com</a></p>"
-               "<p>Copyright &copy; 2012-2017 OpenHantek community<br>"
-               "<a href='https://github.com/OpenHantek/openhantek'>https://github.com/OpenHantek/openhantek</a></p>"));
-
-    });
-}
-
-/// \brief Create the menus and menuitems.
-void OpenHantekMainWindow::createMenus() {
-    fileMenu = menuBar()->addMenu(tr("&File"));
-    fileMenu->addAction(openAction);
-    fileMenu->addAction(saveAction);
-    fileMenu->addAction(saveAsAction);
-    fileMenu->addSeparator();
-    fileMenu->addAction(printAction);
-    fileMenu->addAction(exportAsAction);
-    fileMenu->addSeparator();
-    fileMenu->addAction(exitAction);
-
-    viewMenu = menuBar()->addMenu(tr("&View"));
-    viewMenu->addAction(digitalPhosphorAction);
-    viewMenu->addAction(zoomAction);
-    viewMenu->addSeparator();
-    dockMenu = viewMenu->addMenu(tr("&Docking windows"));
-    dockMenu->addAction(horizontalDock->toggleViewAction());
-    dockMenu->addAction(spectrumDock->toggleViewAction());
-    dockMenu->addAction(triggerDock->toggleViewAction());
-    dockMenu->addAction(voltageDock->toggleViewAction());
-    toolbarMenu = viewMenu->addMenu(tr("&Toolbars"));
-    toolbarMenu->addAction(fileToolBar->toggleViewAction());
-    toolbarMenu->addAction(oscilloscopeToolBar->toggleViewAction());
-    toolbarMenu->addAction(viewToolBar->toggleViewAction());
-
-    oscilloscopeMenu = menuBar()->addMenu(tr("&Oscilloscope"));
-    oscilloscopeMenu->addAction(configAction);
-    oscilloscopeMenu->addSeparator();
-    oscilloscopeMenu->addAction(startStopAction);
-
-    menuBar()->addSeparator();
-
-    helpMenu = menuBar()->addMenu(tr("&Help"));
-    helpMenu->addAction(aboutAction);
-}
-
-namespace {
-
-QToolBar *CreateToolBar(const QString &title) {
-    QToolBar *newObj = new QToolBar(title);
-    newObj->setObjectName(title);
-    newObj->setAllowedAreas(Qt::TopToolBarArea | Qt::LeftToolBarArea);
-    return newObj;
-}
-}
-
-/// \brief Create the toolbars and their buttons.
-void OpenHantekMainWindow::createToolBars() {
-
-    // File
-    fileToolBar = CreateToolBar(tr("File"));
-    fileToolBar->addAction(openAction);
-    fileToolBar->addAction(saveAction);
-    fileToolBar->addAction(saveAsAction);
-    fileToolBar->addSeparator();
-    fileToolBar->addAction(printAction);
-    fileToolBar->addAction(exportAsAction);
-
-    // Oscilloscope
-    oscilloscopeToolBar = CreateToolBar(tr("Oscilloscope"));
-    oscilloscopeToolBar->addAction(startStopAction);
-
-    // View
-    viewToolBar = CreateToolBar(tr("View"));
-    viewToolBar->addAction(digitalPhosphorAction);
-    viewToolBar->addAction(zoomAction);
-}
-
-void OpenHantekMainWindow::addManualCommandEdit() {
     // Command field inside the status bar
-    commandEdit = new QLineEdit();
+    QLineEdit* commandEdit = new QLineEdit(this);
     commandEdit->hide();
-
-    commandAction = new QAction(tr("Send command"), this);
-    commandAction->setShortcut(tr("Shift+C"));
 
     statusBar()->addPermanentWidget(commandEdit, 1);
 
-    oscilloscopeMenu->addSeparator();
-    oscilloscopeMenu->addAction(commandAction);
-
-    connect(commandAction, &QAction::triggered, [this]() {
-        commandEdit->show();
-        commandEdit->setFocus();
+    connect(ui->actionManualCommand, &QAction::toggled, [this, commandEdit](bool checked) {
+        commandEdit->setVisible(checked);
+        if (checked)
+            commandEdit->setFocus();
     });
-    connect(commandEdit, &QLineEdit::returnPressed, [this]() {
-        Dso::ErrorCode errorCode = dsoControl->stringCommand(commandEdit->text());
 
-        commandEdit->hide();
+    connect(commandEdit, &QLineEdit::returnPressed, [this, commandEdit]() {
+        Dso::ErrorCode errorCode = this->dsoControl->stringCommand(commandEdit->text());
         commandEdit->clear();
-
+        this->ui->actionManualCommand->setChecked(false);
         if (errorCode != Dso::ErrorCode::NONE) statusBar()->showMessage(tr("Invalid command"), 3000);
     });
-}
 
-/// \brief Create all docking windows.
-void OpenHantekMainWindow::createDockWindows() {
-    registerDockMetaTypes();
-    horizontalDock = new HorizontalDock(settings, this);
-    triggerDock = new TriggerDock(settings, dsoControl->getSpecialTriggerSources(), this);
-    spectrumDock = new SpectrumDock(settings, this);
-    voltageDock = new VoltageDock(settings, this);
-}
-
-/// \brief Connect general signals and device management signals.
-void OpenHantekMainWindow::connectSignals() {
     // Connect general signals
-    connect(this, &OpenHantekMainWindow::settingsChanged, this, &OpenHantekMainWindow::applySettings);
     connect(dsoControl, &HantekDsoControl::statusMessage, statusBar(), &QStatusBar::showMessage);
 
     // Connect signals to DSO controller and widget
-    connect(horizontalDock, &HorizontalDock::samplerateChanged, this, &OpenHantekMainWindow::samplerateSelected);
-    connect(horizontalDock, &HorizontalDock::timebaseChanged, this, &OpenHantekMainWindow::timebaseSelected);
+    connect(horizontalDock, &HorizontalDock::samplerateChanged, [this]() {
+        this->dsoControl->setSamplerate(this->settings->scope.horizontal.samplerate);
+        this->dsoWidget->updateSamplerate(this->settings->scope.horizontal.samplerate);
+    });
+    connect(horizontalDock, &HorizontalDock::timebaseChanged, [this](){
+        this->dsoControl->setRecordTime(this->settings->scope.horizontal.timebase * DIVS_TIME);
+        this->dsoWidget->updateTimebase(this->settings->scope.horizontal.timebase);
+    });
     connect(horizontalDock, &HorizontalDock::frequencybaseChanged, dsoWidget, &DsoWidget::updateFrequencybase);
-    connect(horizontalDock, &HorizontalDock::recordLengthChanged, this, &OpenHantekMainWindow::recordLengthSelected);
+    connect(horizontalDock, &HorizontalDock::recordLengthChanged, [this](unsigned long recordLength) {
+        this->dsoControl->setRecordLength(recordLength);
+    });
+
+    connect(dsoControl, &HantekDsoControl::recordTimeChanged, [this](double duration) {
+        if (this->settings->scope.horizontal.samplerateSet && this->settings->scope.horizontal.recordLength != UINT_MAX) {
+            // The samplerate was set, let's adapt the timebase accordingly
+            this->settings->scope.horizontal.timebase = horizontalDock->setTimebase(duration / DIVS_TIME);
+        }
+
+        // The trigger position should be kept at the same place but the timebase has
+        // changed
+        this->dsoControl->setPretriggerPosition(this->settings->scope.trigger.position * this->settings->scope.horizontal.timebase *
+                                          DIVS_TIME);
+
+        dsoWidget->updateTimebase(this->settings->scope.horizontal.timebase);
+    });
+    connect(dsoControl, &HantekDsoControl::samplerateChanged, [this](double samplerate) {
+        if (!this->settings->scope.horizontal.samplerateSet && this->settings->scope.horizontal.recordLength != UINT_MAX) {
+            // The timebase was set, let's adapt the samplerate accordingly
+            this->settings->scope.horizontal.samplerate = samplerate;
+            horizontalDock->setSamplerate(samplerate);
+            dsoWidget->updateSamplerate(samplerate);
+        }
+    });
 
     connect(triggerDock, &TriggerDock::modeChanged, dsoControl, &HantekDsoControl::setTriggerMode);
     connect(triggerDock, &TriggerDock::modeChanged, dsoWidget, &DsoWidget::updateTriggerMode);
@@ -301,201 +123,166 @@ void OpenHantekMainWindow::connectSignals() {
     connect(dsoWidget, &DsoWidget::triggerPositionChanged, dsoControl, &HantekDsoControl::setPretriggerPosition);
     connect(dsoWidget, &DsoWidget::triggerLevelChanged, dsoControl, &HantekDsoControl::setTriggerLevel);
 
-    connect(voltageDock, &VoltageDock::usedChanged, this, &OpenHantekMainWindow::updateUsed);
-    connect(voltageDock, &VoltageDock::usedChanged, dsoWidget, &DsoWidget::updateVoltageUsed);
+    auto usedChanged = [this](ChannelID channel, bool used) {
+        if (channel >= (unsigned int)this->settings->scope.voltage.size()) return;
+
+        bool mathUsed = this->settings->scope.anyUsed(this->settings->deviceSpecification->channels);
+
+        // Normal channel, check if voltage/spectrum or math channel is used
+        if (channel < this->settings->deviceSpecification->channels)
+            this->dsoControl->setChannelUsed(
+                channel, mathUsed | this->settings->scope.anyUsed(channel));
+        // Math channel, update all channels
+        else if (channel == this->settings->deviceSpecification->channels) {
+            for (ChannelID c = 0; c < this->settings->deviceSpecification->channels; ++c)
+                this->dsoControl->setChannelUsed(c, mathUsed | this->settings->scope.anyUsed(c));
+        }
+    };
+    connect(voltageDock, &VoltageDock::usedChanged, usedChanged);
+    connect(spectrumDock, &SpectrumDock::usedChanged, usedChanged);
+
     connect(voltageDock, &VoltageDock::couplingChanged, dsoControl, &HantekDsoControl::setCoupling);
     connect(voltageDock, &VoltageDock::couplingChanged, dsoWidget, &DsoWidget::updateVoltageCoupling);
     connect(voltageDock, &VoltageDock::modeChanged, dsoWidget, &DsoWidget::updateMathMode);
-    connect(voltageDock, &VoltageDock::gainChanged, this, &OpenHantekMainWindow::updateVoltageGain);
-    connect(voltageDock, &VoltageDock::gainChanged, dsoWidget, &DsoWidget::updateVoltageGain);
-    connect(dsoWidget, &DsoWidget::offsetChanged, this, &OpenHantekMainWindow::updateOffset);
+    connect(voltageDock, &VoltageDock::gainChanged, [this](ChannelID channel, double gain) {
+        if (channel >= this->settings->deviceSpecification->channels) return;
 
-    connect(spectrumDock, &SpectrumDock::usedChanged, this, &OpenHantekMainWindow::updateUsed);
+        this->dsoControl->setGain(channel, this->settings->scope.gain(channel) * DIVS_VOLTAGE);
+    });
+    connect(voltageDock, &VoltageDock::gainChanged, dsoWidget, &DsoWidget::updateVoltageGain);
+    connect(dsoWidget, &DsoWidget::offsetChanged, [this](ChannelID channel) {
+        if (channel >= this->settings->deviceSpecification->channels) return;
+        this->dsoControl->setOffset(channel, (this->settings->scope.voltage[channel].offset / DIVS_VOLTAGE) + 0.5);
+    });
+
+    connect(voltageDock, &VoltageDock::usedChanged, dsoWidget, &DsoWidget::updateVoltageUsed);
     connect(spectrumDock, &SpectrumDock::usedChanged, dsoWidget, &DsoWidget::updateSpectrumUsed);
     connect(spectrumDock, &SpectrumDock::magnitudeChanged, dsoWidget, &DsoWidget::updateSpectrumMagnitude);
 
     // Started/stopped signals from oscilloscope
-    connect(dsoControl, &HantekDsoControl::samplingStarted, this, &OpenHantekMainWindow::started);
-    connect(dsoControl, &HantekDsoControl::samplingStopped, this, &OpenHantekMainWindow::stopped);
+    connect(dsoControl, &HantekDsoControl::samplingStarted, [this]() {
+        this->ui->actionSampling->setText(tr("&Stop"));
+        this->ui->actionSampling->setIcon(QIcon(":actions/stop.png"));
+        this->ui->actionSampling->setStatusTip(tr("Stop the oscilloscope"));
 
-    connect(dsoControl, &HantekDsoControl::recordTimeChanged, this, &OpenHantekMainWindow::recordTimeChanged);
-    connect(dsoControl, &HantekDsoControl::samplerateChanged, this, &OpenHantekMainWindow::samplerateChanged);
+        disconnect(this->ui->actionSampling, &QAction::triggered, this->dsoControl, &HantekDsoControl::startSampling);
+        connect(this->ui->actionSampling, &QAction::triggered, this->dsoControl, &HantekDsoControl::stopSampling);
+    });
+    connect(dsoControl, &HantekDsoControl::samplingStopped, [this]() {
+        this->ui->actionSampling->setText(tr("&Start"));
+        this->ui->actionSampling->setIcon(QIcon(":actions/start.png"));
+        this->ui->actionSampling->setStatusTip(tr("Start the oscilloscope"));
+
+        disconnect(this->ui->actionSampling, &QAction::triggered, this->dsoControl, &HantekDsoControl::stopSampling);
+        connect(this->ui->actionSampling, &QAction::triggered, this->dsoControl, &HantekDsoControl::startSampling);
+    });
 
     connect(dsoControl, &HantekDsoControl::availableRecordLengthsChanged, horizontalDock,
-            &HorizontalDock::availableRecordLengthsChanged);
+            &HorizontalDock::setAvailableRecordLengths);
     connect(dsoControl, &HantekDsoControl::samplerateLimitsChanged, horizontalDock,
-            &HorizontalDock::samplerateLimitsChanged);
-    connect(dsoControl, &HantekDsoControl::samplerateSet, horizontalDock, &HorizontalDock::samplerateSet);
-}
+            &HorizontalDock::setSamplerateLimits);
+    connect(dsoControl, &HantekDsoControl::samplerateSet, horizontalDock, &HorizontalDock::setSamplerateSteps);
 
-/// \brief Initialize the device with the current settings.
-void OpenHantekMainWindow::applySettingsToDevice() {
-    for (unsigned int channel = 0; channel < settings->deviceSpecification->channels; ++channel) {
-        dsoControl->setCoupling(channel, settings->coupling(channel));
-        updateVoltageGain(channel);
-        updateOffset(channel);
-        dsoControl->setTriggerLevel(channel, settings->scope.voltage[channel].trigger);
-    }
-    updateUsed(settings->deviceSpecification->channels);
+    connect(ui->actionOpen, &QAction::triggered, [this]() {
+        QString fileName = QFileDialog::getOpenFileName(this, tr("Open file"), "", tr("Settings (*.ini)"));
+        if (!fileName.isEmpty()) {
+            if (this->settings->setFilename(fileName)) {
+                this->settings->load();
+            }
+        }
+    });
+
+    connect(ui->actionSave, &QAction::triggered, [this]() {
+        this->settings->mainWindowGeometry = saveGeometry();
+        this->settings->mainWindowState = saveState();
+        this->settings->save();
+    });
+
+    connect(ui->actionSave_as, &QAction::triggered, [this]() {
+        QString fileName = QFileDialog::getSaveFileName(this, tr("Save settings"), "", tr("Settings (*.ini)"));
+        if (fileName.isEmpty()) return;
+        this->settings->mainWindowGeometry = saveGeometry();
+        this->settings->mainWindowState = saveState();
+        this->settings->setFilename(fileName);
+        this->settings->save();
+    });
+
+    connect(ui->actionPrint, &QAction::triggered, [this]() {
+        this->dsoWidget->setExporterForNextFrame(std::unique_ptr<Exporter>(Exporter::createPrintExporter(this->settings)));
+    });
+
+    connect(ui->actionExport, &QAction::triggered, [this]() {
+        this->dsoWidget->setExporterForNextFrame(std::unique_ptr<Exporter>(Exporter::createSaveToFileExporter(this->settings)));
+    });
+
+    connect(ui->actionExit, &QAction::triggered, this, &QWidget::close);
+
+    connect(ui->actionSettings, &QAction::triggered, [this]() {
+        this->settings->mainWindowGeometry = saveGeometry();
+        this->settings->mainWindowState = saveState();
+
+        DsoConfigDialog* configDialog = new DsoConfigDialog(this->settings, this);
+        configDialog->setModal(true);
+        configDialog->show();
+    });
+
+    connect(this->ui->actionDigital_phosphor, &QAction::toggled, [this](bool enabled) {
+        this->settings->view.digitalPhosphor = enabled;
+
+        if (this->settings->view.digitalPhosphor)
+            this->ui->actionDigital_phosphor->setStatusTip(tr("Disable fading of previous graphs"));
+        else
+            this->ui->actionDigital_phosphor->setStatusTip(tr("Enable fading of previous graphs"));
+    });
+    this->ui->actionDigital_phosphor->setChecked(settings->view.digitalPhosphor);
+
+    connect(ui->actionZoom, &QAction::toggled, [this](bool enabled) {
+        this->settings->view.zoom = enabled;
+
+        if (this->settings->view.zoom)
+            this->ui->actionZoom->setStatusTip(tr("Hide magnified scope"));
+        else
+            this->ui->actionZoom->setStatusTip(tr("Show magnified scope"));
+
+        this->dsoWidget->updateZoom(enabled);
+    });
+    ui->actionZoom->setChecked(settings->view.zoom);
+
+    connect(ui->actionAbout, &QAction::triggered, [this]() {
+        QMessageBox::about(
+            this, tr("About OpenHantek %1").arg(VERSION),
+            tr("<p>This is a open source software for Hantek USB oscilloscopes.</p>"
+               "<p>Copyright &copy; 2010, 2011 Oliver Haag<br><a "
+               "href='mailto:oliver.haag@gmail.com'>oliver.haag@gmail.com</a></p>"
+               "<p>Copyright &copy; 2012-2017 OpenHantek community<br>"
+               "<a href='https://github.com/OpenHantek/openhantek'>https://github.com/OpenHantek/openhantek</a></p>"));
+
+    });
+
     if (settings->scope.horizontal.samplerateSet)
-        samplerateSelected();
+        dsoWidget->updateSamplerate(settings->scope.horizontal.samplerate);
     else
-        timebaseSelected();
-    if (dsoControl->getAvailableRecordLengths().empty())
-        dsoControl->setRecordLength(settings->scope.horizontal.recordLength);
-    else {
-        auto recLenVec = dsoControl->getAvailableRecordLengths();
-        ptrdiff_t index = std::distance(
-            recLenVec.begin(), std::find(recLenVec.begin(), recLenVec.end(), settings->scope.horizontal.recordLength));
-        dsoControl->setRecordLength(index < 0 ? 1 : index);
-    }
-    dsoControl->setTriggerMode(settings->scope.trigger.mode);
-    dsoControl->setPretriggerPosition(settings->scope.trigger.position * settings->scope.horizontal.timebase *
-                                      DIVS_TIME);
-    dsoControl->setTriggerSlope(settings->scope.trigger.slope);
-    dsoControl->setTriggerSource(settings->scope.trigger.special, settings->scope.trigger.source);
-}
+        dsoWidget->updateTimebase(settings->scope.horizontal.timebase);
 
-/// \brief The oscilloscope started sampling.
-void OpenHantekMainWindow::started() {
-    startStopAction->setText(tr("&Stop"));
-    startStopAction->setIcon(QIcon(":actions/stop.png"));
-    startStopAction->setStatusTip(tr("Stop the oscilloscope"));
-
-    disconnect(startStopAction, &QAction::triggered, dsoControl, &HantekDsoControl::startSampling);
-    connect(startStopAction, &QAction::triggered, dsoControl, &HantekDsoControl::stopSampling);
-}
-
-/// \brief The oscilloscope stopped sampling.
-void OpenHantekMainWindow::stopped() {
-    startStopAction->setText(tr("&Start"));
-    startStopAction->setIcon(QIcon(":actions/start.png"));
-    startStopAction->setStatusTip(tr("Start the oscilloscope"));
-
-    disconnect(startStopAction, &QAction::triggered, dsoControl, &HantekDsoControl::stopSampling);
-    connect(startStopAction, &QAction::triggered, dsoControl, &HantekDsoControl::startSampling);
-}
-
-/// \brief Enable/disable digital phosphor.
-void OpenHantekMainWindow::digitalPhosphor(bool enabled) {
-    settings->view.digitalPhosphor = enabled;
-
-    if (settings->view.digitalPhosphor)
-        digitalPhosphorAction->setStatusTip(tr("Disable fading of previous graphs"));
-    else
-        digitalPhosphorAction->setStatusTip(tr("Enable fading of previous graphs"));
-}
-
-/// \brief Show/hide the magnified scope.
-void OpenHantekMainWindow::zoom(bool enabled) {
-    settings->view.zoom = enabled;
-
-    if (settings->view.zoom)
-        zoomAction->setStatusTip(tr("Hide magnified scope"));
-    else
-        zoomAction->setStatusTip(tr("Show magnified scope"));
-}
-
-/// \brief The settings have changed.
-void OpenHantekMainWindow::applySettings() {
-    addDockWidget(Qt::RightDockWidgetArea, horizontalDock);
-    addDockWidget(Qt::RightDockWidgetArea, triggerDock);
-    addDockWidget(Qt::RightDockWidgetArea, voltageDock);
-    addDockWidget(Qt::RightDockWidgetArea, spectrumDock);
-
-    addToolBar(fileToolBar);
-    addToolBar(oscilloscopeToolBar);
-    addToolBar(viewToolBar);
-
-    restoreGeometry(settings->mainWindowGeometry);
-    restoreState(settings->mainWindowState);
-}
-
-/// \brief Update the window layout in the settings.
-void OpenHantekMainWindow::saveWindowGeometry() {
-    // Main window
-    settings->mainWindowGeometry = saveGeometry();
-    settings->mainWindowState = saveState();
-}
-
-/// \brief The oscilloscope changed the record time.
-/// \param duration The new record time duration in seconds.
-void OpenHantekMainWindow::recordTimeChanged(double duration) {
-    if (settings->scope.horizontal.samplerateSet && settings->scope.horizontal.recordLength != UINT_MAX) {
-        // The samplerate was set, let's adapt the timebase accordingly
-        settings->scope.horizontal.timebase = horizontalDock->setTimebase(duration / DIVS_TIME);
-    }
-
-    // The trigger position should be kept at the same place but the timebase has
-    // changed
-    dsoControl->setPretriggerPosition(settings->scope.trigger.position * settings->scope.horizontal.timebase *
-                                      DIVS_TIME);
-
-    dsoWidget->updateTimebase(settings->scope.horizontal.timebase);
-}
-
-/// \brief The oscilloscope changed the samplerate.
-/// \param samplerate The new samplerate in samples per second.
-void OpenHantekMainWindow::samplerateChanged(double samplerate) {
-    if (!settings->scope.horizontal.samplerateSet && settings->scope.horizontal.recordLength != UINT_MAX) {
-        // The timebase was set, let's adapt the samplerate accordingly
-        settings->scope.horizontal.samplerate = samplerate;
-        horizontalDock->setSamplerate(samplerate);
-        dsoWidget->updateSamplerate(samplerate);
+    for (ChannelID channel = 0; channel < settings->deviceSpecification->channels; ++channel) {
+        this->dsoWidget->updateVoltageUsed(channel, settings->scope.voltage[channel].used);
+        this->dsoWidget->updateSpectrumUsed(channel, settings->scope.spectrum[channel].used);
     }
 }
 
-/// \brief Apply new record length to settings.
-/// \param recordLength The selected record length in samples.
-void OpenHantekMainWindow::recordLengthSelected(unsigned long recordLength) {
-    dsoControl->setRecordLength(recordLength);
+MainWindow::~MainWindow()
+{
+    delete ui;
 }
 
-/// \brief Sets the samplerate of the oscilloscope.
-void OpenHantekMainWindow::samplerateSelected() {
-    dsoControl->setSamplerate(settings->scope.horizontal.samplerate);
-    dsoWidget->updateSamplerate(settings->scope.horizontal.samplerate);
-}
-
-/// \brief Sets the record time of the oscilloscope.
-void OpenHantekMainWindow::timebaseSelected() {
-    dsoControl->setRecordTime(settings->scope.horizontal.timebase * DIVS_TIME);
-    dsoWidget->updateTimebase(settings->scope.horizontal.timebase);
-}
-
-/// \brief Sets the offset of the oscilloscope for the given channel.
-/// \param channel The channel that got a new offset.
-void OpenHantekMainWindow::updateOffset(unsigned int channel) {
-    if (channel >= settings->deviceSpecification->channels) return;
-
-    dsoControl->setOffset(channel, (settings->scope.voltage[channel].offset / DIVS_VOLTAGE) + 0.5);
-}
-
-/// \brief Sets the state of the given oscilloscope channel.
-/// \param channel The channel whose state has changed.
-void OpenHantekMainWindow::updateUsed(unsigned int channel) {
-    if (channel >= (unsigned int)settings->scope.voltage.size()) return;
-
-    bool mathUsed = settings->scope.voltage[settings->deviceSpecification->channels].used |
-                    settings->scope.spectrum[settings->deviceSpecification->channels].used;
-
-    // Normal channel, check if voltage/spectrum or math channel is used
-    if (channel < settings->deviceSpecification->channels)
-        dsoControl->setChannelUsed(
-            channel, mathUsed | settings->scope.voltage[channel].used | settings->scope.spectrum[channel].used);
-    // Math channel, update all channels
-    else if (channel == settings->deviceSpecification->channels) {
-        for (unsigned int channelCounter = 0; channelCounter < settings->deviceSpecification->channels; ++channelCounter)
-            dsoControl->setChannelUsed(channelCounter,
-                                       mathUsed | settings->scope.voltage[channelCounter].used |
-                                           settings->scope.spectrum[channelCounter].used);
+/// \brief Save the settings before exiting.
+/// \param event The close event that should be handled.
+void MainWindow::closeEvent(QCloseEvent *event) {
+    if (settings->options.alwaysSave) {
+        settings->mainWindowGeometry = saveGeometry();
+        settings->mainWindowState = saveState();
+        settings->save();
     }
-}
 
-/// \brief Sets the gain of the oscilloscope for the given channel.
-/// \param channel The channel that got a new gain value.
-void OpenHantekMainWindow::updateVoltageGain(unsigned int channel) {
-    if (channel >= settings->deviceSpecification->channels) return;
-
-    dsoControl->setGain(channel, settings->scope.gain(channel) * DIVS_VOLTAGE);
+    QMainWindow::closeEvent(event);
 }

--- a/openhantek/src/mainwindow.h
+++ b/openhantek/src/mainwindow.h
@@ -1,13 +1,5 @@
-// SPDX-License-Identifier: GPL-2.0+
-
 #pragma once
-
 #include <QMainWindow>
-#include <QTimer>
-#include <memory>
-
-class QActionGroup;
-class QLineEdit;
 
 class DataAnalyzer;
 class HantekDsoControl;
@@ -18,54 +10,25 @@ class TriggerDock;
 class SpectrumDock;
 class VoltageDock;
 
-////////////////////////////////////////////////////////////////////////////////
-/// \class OpenHantekMainWindow                                     openhantek.h
+namespace Ui {
+class MainWindow;
+}
+
 /// \brief The main window of the application.
 /// The main window contains the classic oszilloscope-screen and the gui
 /// elements used to control the oszilloscope.
-class OpenHantekMainWindow : public QMainWindow {
+class MainWindow : public QMainWindow
+{
     Q_OBJECT
 
-  public:
-    OpenHantekMainWindow(HantekDsoControl *dsoControl, DataAnalyzer *dataAnalyser, DsoSettings *settings);
+public:
+    explicit MainWindow(HantekDsoControl *dsoControl, DataAnalyzer *dataAnalyser, DsoSettings *settings, QWidget *parent = 0);
+    ~MainWindow();
 
-  protected:
-    void closeEvent(QCloseEvent *event);
-
-  private:
-    // GUI creation
-    void createActions();
-    void createMenus();
-    void createToolBars();
-    void addManualCommandEdit();
-    void createDockWindows();
-
-    // Device management
-    void connectSignals();
-    void applySettingsToDevice();
-
-    // Actions
-    QAction *newAction, *openAction, *saveAction, *saveAsAction;
-    QAction *printAction, *exportAsAction;
-    QAction *exitAction;
-
-    QAction *configAction;
-    QAction *startStopAction;
-    QAction *digitalPhosphorAction, *zoomAction;
-
-    QAction *aboutAction;
-
-    QAction *commandAction; ///< Only used if DEBUG is on
-    QLineEdit *commandEdit; ///< Only used if DEBUG is on
-
-    // Menus
-    QMenu *fileMenu;
-    QMenu *viewMenu, *dockMenu, *toolbarMenu;
-    QMenu *oscilloscopeMenu;
-    QMenu *helpMenu;
-
-    // Toolbars
-    QToolBar *fileToolBar, *oscilloscopeToolBar, *viewToolBar;
+protected:
+    void closeEvent(QCloseEvent *event) override;
+private:
+    Ui::MainWindow *ui;
 
     // Docking windows
     HorizontalDock *horizontalDock;
@@ -82,28 +45,4 @@ class OpenHantekMainWindow : public QMainWindow {
 
     // Settings used for the whole program
     DsoSettings *settings;
-
-  private slots:
-    // View
-    void digitalPhosphor(bool enabled);
-    void zoom(bool enabled);
-    // Oscilloscope control
-    void started();
-    void stopped();
-
-    // Settings management
-    void applySettings();
-    void saveWindowGeometry();
-
-    void recordTimeChanged(double duration);
-    void samplerateChanged(double samplerate);
-    void recordLengthSelected(unsigned long recordLength);
-    void samplerateSelected();
-    void timebaseSelected();
-    void updateOffset(unsigned int channel);
-    void updateUsed(unsigned int channel);
-    void updateVoltageGain(unsigned int channel);
-
-  signals:
-    void settingsChanged(); ///< The settings have changed (Option dialog, loading...)
 };

--- a/openhantek/src/mainwindow.ui
+++ b/openhantek/src/mainwindow.ui
@@ -1,0 +1,224 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>MainWindow</class>
+ <widget class="QMainWindow" name="MainWindow">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>800</width>
+    <height>600</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>MainWindow</string>
+  </property>
+  <widget class="QWidget" name="centralwidget"/>
+  <widget class="QMenuBar" name="menubar">
+   <property name="geometry">
+    <rect>
+     <x>0</x>
+     <y>0</y>
+     <width>800</width>
+     <height>25</height>
+    </rect>
+   </property>
+   <widget class="QMenu" name="menuFile">
+    <property name="title">
+     <string>&amp;File</string>
+    </property>
+    <addaction name="actionOpen"/>
+    <addaction name="actionSave"/>
+    <addaction name="actionSave_as"/>
+    <addaction name="separator"/>
+    <addaction name="actionPrint"/>
+    <addaction name="actionExport"/>
+    <addaction name="separator"/>
+    <addaction name="actionExit"/>
+   </widget>
+   <widget class="QMenu" name="menuView">
+    <property name="title">
+     <string>&amp;View</string>
+    </property>
+    <addaction name="actionDigital_phosphor"/>
+    <addaction name="actionZoom"/>
+    <addaction name="actionManualCommand"/>
+   </widget>
+   <widget class="QMenu" name="menuOscilloscope">
+    <property name="title">
+     <string>&amp;Oscilloscope</string>
+    </property>
+    <addaction name="actionSettings"/>
+    <addaction name="separator"/>
+    <addaction name="actionSampling"/>
+   </widget>
+   <widget class="QMenu" name="menuHelp">
+    <property name="title">
+     <string>&amp;Help</string>
+    </property>
+    <addaction name="actionAbout"/>
+   </widget>
+   <addaction name="menuFile"/>
+   <addaction name="menuView"/>
+   <addaction name="menuOscilloscope"/>
+   <addaction name="menuHelp"/>
+  </widget>
+  <widget class="QStatusBar" name="statusbar"/>
+  <widget class="QToolBar" name="toolBar">
+   <property name="windowTitle">
+    <string>toolBar</string>
+   </property>
+   <attribute name="toolBarArea">
+    <enum>TopToolBarArea</enum>
+   </attribute>
+   <attribute name="toolBarBreak">
+    <bool>false</bool>
+   </attribute>
+   <addaction name="actionOpen"/>
+   <addaction name="actionSave"/>
+   <addaction name="actionSave_as"/>
+   <addaction name="separator"/>
+   <addaction name="actionPrint"/>
+   <addaction name="actionExport"/>
+   <addaction name="separator"/>
+   <addaction name="actionSampling"/>
+   <addaction name="separator"/>
+   <addaction name="actionDigital_phosphor"/>
+   <addaction name="actionZoom"/>
+  </widget>
+  <action name="actionOpen">
+   <property name="icon">
+    <iconset resource="../res/application.qrc">
+     <normaloff>:/actions/open.png</normaloff>:/actions/open.png</iconset>
+   </property>
+   <property name="text">
+    <string>Open</string>
+   </property>
+   <property name="shortcut">
+    <string>Ctrl+O</string>
+   </property>
+  </action>
+  <action name="actionSave">
+   <property name="icon">
+    <iconset resource="../res/application.qrc">
+     <normaloff>:/actions/save.png</normaloff>:/actions/save.png</iconset>
+   </property>
+   <property name="text">
+    <string>Save</string>
+   </property>
+   <property name="shortcut">
+    <string>Ctrl+S</string>
+   </property>
+  </action>
+  <action name="actionSave_as">
+   <property name="icon">
+    <iconset resource="../res/application.qrc">
+     <normaloff>:/actions/save-as.png</normaloff>:/actions/save-as.png</iconset>
+   </property>
+   <property name="text">
+    <string>Save as ...</string>
+   </property>
+  </action>
+  <action name="actionPrint">
+   <property name="icon">
+    <iconset resource="../res/application.qrc">
+     <normaloff>:/actions/print.png</normaloff>:/actions/print.png</iconset>
+   </property>
+   <property name="text">
+    <string>Print</string>
+   </property>
+   <property name="shortcut">
+    <string>Ctrl+P</string>
+   </property>
+  </action>
+  <action name="actionExport">
+   <property name="icon">
+    <iconset resource="../res/application.qrc">
+     <normaloff>:/actions/export-as.png</normaloff>:/actions/export-as.png</iconset>
+   </property>
+   <property name="text">
+    <string>Export as ...</string>
+   </property>
+   <property name="shortcut">
+    <string>Ctrl+E</string>
+   </property>
+  </action>
+  <action name="actionExit">
+   <property name="text">
+    <string>Exit</string>
+   </property>
+  </action>
+  <action name="actionDigital_phosphor">
+   <property name="checkable">
+    <bool>true</bool>
+   </property>
+   <property name="icon">
+    <iconset resource="../res/application.qrc">
+     <normaloff>:/actions/digitalphosphor.png</normaloff>:/actions/digitalphosphor.png</iconset>
+   </property>
+   <property name="text">
+    <string>Digital phosphor</string>
+   </property>
+  </action>
+  <action name="actionZoom">
+   <property name="checkable">
+    <bool>true</bool>
+   </property>
+   <property name="icon">
+    <iconset resource="../res/application.qrc">
+     <normaloff>:/actions/zoom.png</normaloff>:/actions/zoom.png</iconset>
+   </property>
+   <property name="text">
+    <string>Zoom</string>
+   </property>
+  </action>
+  <action name="actionDocking_windows">
+   <property name="text">
+    <string>Docking windows</string>
+   </property>
+  </action>
+  <action name="actionToolbars">
+   <property name="text">
+    <string>Toolbars</string>
+   </property>
+  </action>
+  <action name="actionAbout">
+   <property name="text">
+    <string>About</string>
+   </property>
+  </action>
+  <action name="actionSettings">
+   <property name="text">
+    <string>Settings</string>
+   </property>
+  </action>
+  <action name="actionSampling">
+   <property name="checkable">
+    <bool>true</bool>
+   </property>
+   <property name="icon">
+    <iconset resource="../res/application.qrc">
+     <normaloff>:/actions/stop.png</normaloff>
+     <normalon>:/actions/start.png</normalon>:/actions/stop.png</iconset>
+   </property>
+   <property name="text">
+    <string>Sampling</string>
+   </property>
+   <property name="shortcut">
+    <string>Space</string>
+   </property>
+  </action>
+  <action name="actionManualCommand">
+   <property name="checkable">
+    <bool>true</bool>
+   </property>
+   <property name="text">
+    <string>Manual command</string>
+   </property>
+  </action>
+ </widget>
+ <resources>
+  <include location="../res/application.qrc"/>
+ </resources>
+ <connections/>
+</ui>

--- a/openhantek/src/scopesettings.h
+++ b/openhantek/src/scopesettings.h
@@ -7,6 +7,7 @@
 #include "analyse/enums.h"
 #include "hantekdso/enums.h"
 #include "hantekprotocol/definitions.h"
+#include "hantekdso/controlspecification.h"
 #include <vector>
 
 #define MARKER_COUNT 2 ///< Number of markers
@@ -72,4 +73,12 @@ struct DsoSettingsScope {
     double gain(unsigned channel) const {
         return gainSteps[voltage[channel].gainStepIndex];
     }
+    bool anyUsed(ChannelID channel) {
+        return voltage[channel].used | spectrum[channel].used;
+    }
+
+    Dso::Coupling coupling(ChannelID channel, const Dso::ControlSpecification* deviceSpecification) {
+        return deviceSpecification->couplings[voltage[channel].couplingIndex];
+    }
+
 };

--- a/openhantek/src/settings.cpp
+++ b/openhantek/src/settings.cpp
@@ -11,8 +11,8 @@
 
 /// \brief Set the number of channels.
 /// \param channels The new channel count, that will be applied to lists.
-DsoSettings::DsoSettings(const Dso::ControlSettings* deviceSettings, const Dso::ControlSpecification* deviceSpecification)
-    : deviceSettings(deviceSettings), deviceSpecification(deviceSpecification) {
+DsoSettings::DsoSettings(const Dso::ControlSpecification* deviceSpecification)
+    : deviceSpecification(deviceSpecification) {
 
     // Add new channels to the list
     while (scope.spectrum.size() < deviceSpecification->channels) {

--- a/openhantek/src/settings.h
+++ b/openhantek/src/settings.h
@@ -25,7 +25,7 @@ struct DsoSettingsOptions {
 /// \brief Holds the settings of the program.
 class DsoSettings {
   public:
-    explicit DsoSettings(const Dso::ControlSettings* deviceSettings, const Dso::ControlSpecification* deviceSpecification);
+    explicit DsoSettings(const Dso::ControlSpecification* deviceSpecification);
     bool setFilename(const QString &filename);
 
     DsoSettingsOptions options; ///< General options of the program
@@ -33,12 +33,7 @@ class DsoSettings {
     DsoSettingsView view;       ///< All view related settings
 
     // Read only access to device settings and device specification
-    const Dso::ControlSettings* deviceSettings;
     const Dso::ControlSpecification* deviceSpecification;
-
-    Dso::Coupling coupling(ChannelID channel) {
-        return deviceSpecification->couplings[scope.voltage[channel].couplingIndex];
-    }
 
     QByteArray mainWindowGeometry; ///< Geometry of the main window
     QByteArray mainWindowState;    ///< State of docking windows and toolbars

--- a/openhantek/src/widgets/levelslider.cpp
+++ b/openhantek/src/widgets/levelslider.cpp
@@ -59,13 +59,13 @@ int LevelSlider::postMargin() const { return this->_postMargin; }
 /// \brief Add a new slider to the slider container.
 /// \param index The index where the slider should be inserted, 0 to append.
 /// \return The index of the slider, -1 on error.
-int LevelSlider::addSlider(int index) { return this->addSlider(0, index); }
+int LevelSlider::addSlider(int index) { return this->addSlider("0", index); }
 
 /// \brief Add a new slider to the slider container.
 /// \param text The text that will be shown next to the slider.
 /// \param index The index where the slider should be inserted, 0 to append.
 /// \return The index of the slider, -1 on error.
-int LevelSlider::addSlider(QString text, int index) {
+int LevelSlider::addSlider(const QString& text, int index) {
     if (index < -1) return -1;
 
     LevelSliderParameters *parameters = new LevelSliderParameters;
@@ -146,7 +146,7 @@ const QString LevelSlider::text(int index) const {
 /// \param index The index of the slider whose text should be set.
 /// \param text The text shown next to the slider.
 /// \return The index of the slider, -1 on error.
-int LevelSlider::setText(int index, QString text) {
+int LevelSlider::setText(int index, const QString &text) {
     if (index < 0 || index >= this->slider.count()) return -1;
 
     this->slider[index]->text = text;

--- a/openhantek/src/widgets/levelslider.h
+++ b/openhantek/src/widgets/levelslider.h
@@ -38,14 +38,14 @@ class LevelSlider : public QWidget {
     int postMargin() const;
 
     int addSlider(int index = -1);
-    int addSlider(QString text, int index = -1);
+    int addSlider(const QString &text, int index = -1);
     int removeSlider(int index = -1);
 
     // Parameters for a specific slider
     const QColor color(int index) const;
     void setColor(unsigned index, QColor color);
     const QString text(int index) const;
-    int setText(int index, QString text);
+    int setText(int index, const QString &text);
     bool visible(int index) const;
     void setIndexVisible(unsigned index, bool visible);
 


### PR DESCRIPTION
* Dock widgets: Use scope settings and lambdas instead of private slots. Block signals for set methods.
* Rewrite MainWindow with a UI file.
* MainWindow: Only connect widget signals/slots. Use lambdas instead of private slots.
  Don't initialize hantekdsocontrol with user settings. This is done in main.cpp now.

Bigger picture:
* The core part should not rely on the graphical part to function -> For unit tests and implementation tests.
* All graphical interfaces should be migrated to UI files to separate interface code from controller logic.