### PR TITLE
Slider granularity enhancement, trigger level & position slider view fix

### DIFF
--- a/openhantek/src/docks/dockwindows.cpp
+++ b/openhantek/src/docks/dockwindows.cpp
@@ -32,5 +32,5 @@ void registerDockMetaTypes() {
     qRegisterMetaType<Dso::InterpolationMode>();
     qRegisterMetaType<std::vector<unsigned> >();
     qRegisterMetaType<std::vector<double> >();
-    qRegisterMetaType<ChannelID>();
+    qRegisterMetaType<ChannelID>("ChannelID");
 }

--- a/openhantek/src/dsowidget.cpp
+++ b/openhantek/src/dsowidget.cpp
@@ -75,7 +75,7 @@ DsoWidget::DsoWidget(DsoSettingsScope *scope, DsoSettingsView *view, const Dso::
     for (int marker = 0; marker < MARKER_COUNT; ++marker) {
         markerSlider->addSlider(QString::number(marker + 1), marker);
         markerSlider->setLimits(marker, -DIVS_TIME / 2, DIVS_TIME / 2);
-        markerSlider->setStep(marker, 0.2);
+        markerSlider->setStep(marker, DIVS_TIME / 100.0);
         markerSlider->setValue(marker, scope->horizontal.marker[marker]);
         markerSlider->setIndexVisible(marker, true);
     }
@@ -241,7 +241,7 @@ void DsoWidget::adaptTriggerLevelSlider(ChannelID channel) {
     triggerLevelSlider->setLimits(
         (int)channel, (-DIVS_VOLTAGE / 2 - scope->voltage[channel].offset) * scope->gain(channel),
         (DIVS_VOLTAGE / 2 - scope->voltage[channel].offset) * scope->gain(channel));
-    triggerLevelSlider->setStep((int)channel, scope->gain(channel) * 0.2);
+    triggerLevelSlider->setStep((int)channel, scope->gain(channel) * 0.05);
 }
 
 /// \brief Show/Hide a line of the measurement table.

--- a/openhantek/src/selectdevice/selectsupporteddevice.cpp
+++ b/openhantek/src/selectdevice/selectsupporteddevice.cpp
@@ -21,7 +21,7 @@ SelectSupportedDevice::SelectSupportedDevice(QWidget *parent) :
     ui->setupUi(this);
     newDeviceFromExistingDialog = new NewDeviceModelFromExisting(this);
     ui->buttonBox->button(QDialogButtonBox::Ok)->setEnabled(false);
-    qRegisterMetaType<UniqueUSBid>();
+    qRegisterMetaType<UniqueUSBid>("UniqueUSBid");
     connect(ui->buttonBox, &QDialogButtonBox::accepted, [this]() {
         if (ui->cmbDevices->currentIndex()!=-1) {
             selectedDevice = ui->cmbDevices->currentData(Qt::UserRole).value<UniqueUSBid>();

--- a/openhantek/src/utils/printutils.cpp
+++ b/openhantek/src/utils/printutils.cpp
@@ -50,11 +50,11 @@ QString valueToString(double value, Unit unit, int precision) {
     case UNIT_VOLTS: {
         // Voltage string representation
         int logarithm = floor(log10(fabs(value)));
-        if (value < 1e-3)
+        if (fabs(value) < 1e-3)
             return QApplication::tr("%L1 µV").arg(value / 1e-6, 0, format,
                                                   (precision <= 0) ? precision
                                                                    : qBound(0, precision - 7 - logarithm, precision));
-        else if (value < 1.0)
+        else if (fabs(value) < 1.0)
             return QApplication::tr("%L1 mV").arg(value / 1e-3, 0, format,
                                                   (precision <= 0) ? precision : (precision - 4 - logarithm));
         else
@@ -69,26 +69,26 @@ QString valueToString(double value, Unit unit, int precision) {
 
     case UNIT_SECONDS:
         // Time string representation
-        if (value < 1e-9)
+        if (fabs(value) < 1e-9)
             return QApplication::tr("%L1 ps").arg(
                 value / 1e-12, 0, format,
                 (precision <= 0) ? precision : qBound(0, precision - 13 - (int)floor(log10(fabs(value))), precision));
-        else if (value < 1e-6)
+        else if (fabs(value) < 1e-6)
             return QApplication::tr("%L1 ns").arg(value / 1e-9, 0, format,
                                                   (precision <= 0) ? precision
                                                                    : (precision - 10 - (int)floor(log10(fabs(value)))));
-        else if (value < 1e-3)
+        else if (fabs(value) < 1e-3)
             return QApplication::tr("%L1 µs").arg(value / 1e-6, 0, format,
                                                   (precision <= 0) ? precision
                                                                    : (precision - 7 - (int)floor(log10(fabs(value)))));
-        else if (value < 1.0)
+        else if (fabs(value) < 1.0)
             return QApplication::tr("%L1 ms").arg(value / 1e-3, 0, format,
                                                   (precision <= 0) ? precision
                                                                    : (precision - 4 - (int)floor(log10(fabs(value)))));
-        else if (value < 60)
+        else if (fabs(value) < 60)
             return QApplication::tr("%L1 s").arg(
                 value, 0, format, (precision <= 0) ? precision : (precision - 1 - (int)floor(log10(fabs(value)))));
-        else if (value < 3600)
+        else if (fabs(value) < 3600)
             return QApplication::tr("%L1 min").arg(
                 value / 60, 0, format, (precision <= 0) ? precision : (precision - 1 - (int)floor(log10(value / 60))));
         else
@@ -99,13 +99,13 @@ QString valueToString(double value, Unit unit, int precision) {
     case UNIT_HERTZ: {
         // Frequency string representation
         int logarithm = floor(log10(fabs(value)));
-        if (value < 1e3)
+        if (fabs(value) < 1e3)
             return QApplication::tr("%L1 Hz").arg(
                 value, 0, format, (precision <= 0) ? precision : qBound(0, precision - 1 - logarithm, precision));
-        else if (value < 1e6)
+        else if (fabs(value) < 1e6)
             return QApplication::tr("%L1 kHz").arg(value / 1e3, 0, format,
                                                    (precision <= 0) ? precision : precision + 2 - logarithm);
-        else if (value < 1e9)
+        else if (fabs(value) < 1e9)
             return QApplication::tr("%L1 MHz").arg(value / 1e6, 0, format,
                                                    (precision <= 0) ? precision : precision + 5 - logarithm);
         else
@@ -115,13 +115,13 @@ QString valueToString(double value, Unit unit, int precision) {
     case UNIT_SAMPLES: {
         // Sample count string representation
         int logarithm = floor(log10(fabs(value)));
-        if (value < 1e3)
+        if (fabs(value) < 1e3)
             return QApplication::tr("%L1 S").arg(
                 value, 0, format, (precision <= 0) ? precision : qBound(0, precision - 1 - logarithm, precision));
-        else if (value < 1e6)
+        else if (fabs(value) < 1e6)
             return QApplication::tr("%L1 kS").arg(value / 1e3, 0, format,
                                                   (precision <= 0) ? precision : precision + 2 - logarithm);
-        else if (value < 1e9)
+        else if (fabs(value) < 1e9)
             return QApplication::tr("%L1 MS").arg(value / 1e6, 0, format,
                                                   (precision <= 0) ? precision : precision + 5 - logarithm);
         else

--- a/openhantek/src/widgets/levelslider.cpp
+++ b/openhantek/src/widgets/levelslider.cpp
@@ -59,7 +59,7 @@ int LevelSlider::postMargin() const { return this->_postMargin; }
 /// \brief Add a new slider to the slider container.
 /// \param index The index where the slider should be inserted, 0 to append.
 /// \return The index of the slider, -1 on error.
-int LevelSlider::addSlider(int index) { return this->addSlider("0", index); }
+int LevelSlider::addSlider(int index) { return this->addSlider("", index); }
 
 /// \brief Add a new slider to the slider container.
 /// \param text The text that will be shown next to the slider.


### PR DESCRIPTION
- Bugfix: Show "needle" in trigger position/level sliders, fix regression introduced by 0fb7e43.
![screenshot from 2018-01-06 19-29-39](https://user-images.githubusercontent.com/11679699/34641752-dc43c7f4-f319-11e7-8c4f-14176fc0c1db.png)
![screenshot from 2018-01-06 19-40-51](https://user-images.githubusercontent.com/11679699/34641754-df6e1d12-f319-11e7-8a24-1ccdcc8595c1.png)

- Bugfix: valueToString() fails to display negative values. Later on I'm planning an enhancement which shows marker 1/2 values in DsoWidget (relative to trigger position).

- Enhancement: marker position granularity is now 1% of DIVS_TIME, trigger level is 5% of full scale.
  