### PR TITLE
drag markers by mouse press in the scope area

### DIFF
--- a/openhantek/src/exporter.cpp
+++ b/openhantek/src/exporter.cpp
@@ -64,7 +64,7 @@ std::unique_ptr<QPrinter> Exporter::printPaintDevice(DsoSettings *settings) {
 }
 
 bool Exporter::exportSamples(const DataAnalyzerResult *result) {
-    if (this->format == EXPORT_FORMAT_CSV) { return exportCVS(result); }
+    if (this->format == EXPORT_FORMAT_CSV) { return exportCSV(result); }
 
     // Choose the color values we need
     DsoSettingsColorValues *colorValues;
@@ -136,7 +136,7 @@ bool Exporter::exportSamples(const DataAnalyzerResult *result) {
         // Draw the measurement table
         stretchBase = (double)(paintDevice->width() - lineHeight * 6) / 10;
         int channelCount = 0;
-        for (ChannelID channel = settings->scope.voltage.size() - 1; channel >= 0; channel--) {
+        for (int channel = settings->scope.voltage.size() - 1; channel >= 0; channel--) {
             if ((settings->scope.voltage[channel].used || settings->scope.spectrum[channel].used) &&
                 result->data(channel)) {
                 ++channelCount;
@@ -329,7 +329,7 @@ bool Exporter::exportSamples(const DataAnalyzerResult *result) {
     return true;
 }
 
-bool Exporter::exportCVS(const DataAnalyzerResult *result) {
+bool Exporter::exportCSV(const DataAnalyzerResult *result) {
     QFile csvFile(this->filename);
     if (!csvFile.open(QIODevice::WriteOnly | QIODevice::Text)) return false;
 

--- a/openhantek/src/exporter.h
+++ b/openhantek/src/exporter.h
@@ -30,7 +30,7 @@ class Exporter {
   private:
     Exporter(DsoSettings *settings, const QString &filename, ExportFormat format);
     void setFormat(ExportFormat format);
-    bool exportCVS(const DataAnalyzerResult *result);
+    bool exportCSV(const DataAnalyzerResult *result);
     static std::unique_ptr<QPrinter> printPaintDevice(DsoSettings *settings);
     void drawGrids(QPainter &painter, DsoSettingsColorValues *colorValues, double lineHeight, double scopeHeight,
                    int scopeWidth);

--- a/openhantek/src/glscope.h
+++ b/openhantek/src/glscope.h
@@ -46,6 +46,10 @@ class GlScope : public GL_WIDGET_CLASS {
     /// \param height The new height of the widget.
     void resizeGL(int width, int height) override;
 
+    void mousePressEvent(QMouseEvent *event) override;
+    void mouseMoveEvent(QMouseEvent *event) override;
+    void mouseReleaseEvent(QMouseEvent *event) override;
+
     /// \brief Draw the grid.
     void drawGrid();
 
@@ -59,7 +63,11 @@ class GlScope : public GL_WIDGET_CLASS {
      */
     bool channelUsed(Dso::ChannelMode mode, ChannelID channel);
 
+  signals:
+    void markerMoved(int marker, double position);
+
   private:
+    const int NO_MARKER = -1;
     DsoSettingsScope *scope;
     DsoSettingsView *view;
     const GlGenerator *generator;
@@ -67,4 +75,5 @@ class GlScope : public GL_WIDGET_CLASS {
 
     std::vector<GLfloat> vaMarker[2];
     bool zoomed = false;
+    int selectedMarker = NO_MARKER;
 };


### PR DESCRIPTION
- **Marker enhancements.** The user can move marker by mouse drag in the scope area. If left mouse button is pressed close to an existing marker (+/- 1% of horizontal axis), the marker is selected for dragging. Mouse press outside snap area will move Marker 1 to that position, mouse release will set Marker 2.
- Marker positions relative to trigger are displayed in the info label area. Not yet in print / PDF export; those require deep refactoring to show channel offsets, trigger position & level, etc. etc.
Normal view, Marker 1 has positive offset against trigger, Marker 2 has negative offset:
![screenshot from 2018-01-07 23-51-54](https://user-images.githubusercontent.com/11679699/34654005-63e73258-f406-11e7-838b-022828ba588d.png)
Zoom view:
![screenshot from 2018-01-07 23-21-02](https://user-images.githubusercontent.com/11679699/34653938-3ba6e438-f405-11e7-9cfa-6d19292aa339.png)
- **BUGFIX** unsigned int is not good if the loop counts down to 0. Transition to ChannelID everywhere in the code broke exporter.