### PR TITLE
Add sliders to the zoom view

### DIFF
--- a/openhantek/src/dsowidget.h
+++ b/openhantek/src/dsowidget.h
@@ -23,6 +23,13 @@ struct DsoSettingsView;
 class DsoWidget : public QWidget {
     Q_OBJECT
 
+    struct Sliders {
+        LevelSlider *offsetSlider;          ///< The sliders for the graph offsets
+        LevelSlider *triggerPositionSlider; ///< The slider for the pretrigger
+        LevelSlider *triggerLevelSlider;    ///< The sliders for the trigger level
+        LevelSlider *markerSlider;          ///< The sliders for the markers
+    };
+
   public:
     /// \brief Initializes the components of the oszilloscope-screen.
     /// \param settings The settings object containing the oscilloscope settings.
@@ -34,18 +41,19 @@ class DsoWidget : public QWidget {
     void setExporterForNextFrame(std::unique_ptr<Exporter> exporter);
 
   protected:
-    void adaptTriggerLevelSlider(ChannelID channel);
-    void setMeasurementVisible(ChannelID channel, bool visible);
+    void setupSliders(Sliders &sliders);
+    void adaptTriggerLevelSlider(DsoWidget::Sliders &sliders, ChannelID channel);
+    void adaptTriggerPositionSlider();
+    void setMeasurementVisible(ChannelID channel);
     void updateMarkerDetails();
     void updateSpectrumDetails(ChannelID channel);
     void updateTriggerDetails();
     void updateVoltageDetails(ChannelID channel);
 
+    Sliders mainSliders;
+    Sliders zoomSliders;
+
     QGridLayout *mainLayout;            ///< The main layout for this widget
-    LevelSlider *offsetSlider;          ///< The sliders for the graph offsets
-    LevelSlider *triggerPositionSlider; ///< The slider for the pretrigger
-    LevelSlider *triggerLevelSlider;    ///< The sliders for the trigger level
-    LevelSlider *markerSlider;          ///< The sliders for the markers
 
     QHBoxLayout *settingsLayout;        ///< The table for the settings info
     QLabel *settingsTriggerLabel;       ///< The trigger details
@@ -80,6 +88,7 @@ class DsoWidget : public QWidget {
     GlScope *zoomScope;     ///< The optional magnified scope screen
     std::unique_ptr<Exporter> exportNextFrame;
     std::unique_ptr<DataAnalyzerResult> data;
+
   public slots:
     // Horizontal axis
     // void horizontalFormatChanged(HorizontalFormat format);

--- a/openhantek/src/widgets/levelslider.cpp
+++ b/openhantek/src/widgets/levelslider.cpp
@@ -311,6 +311,7 @@ void LevelSlider::mouseMoveEvent(QMouseEvent *event) {
         this->setValue(this->pressedSlider,
                        floor(value / this->slider[pressedSlider]->step + 0.5) * this->slider[pressedSlider]->step);
 
+    emit valueChanged(pressedSlider, slider[pressedSlider]->value);
     event->accept();
 }
 
@@ -414,7 +415,7 @@ void LevelSlider::paintEvent(QPaintEvent *event) {
                 break;
             }
 
-            painter.setBrush(QBrush((*slider)->color, Qt::SolidPattern));
+            painter.setBrush(QBrush((*slider)->color, isEnabled() ? Qt::SolidPattern : Qt::NoBrush));
             painter.drawPolygon(QPolygon(needlePoints));
             painter.setBrush(Qt::NoBrush);
         } else {


### PR DESCRIPTION
Channel offset, trigger level and trigger position sliders are attached to zoom view. First two slider sets behave as active mirrors of respective main sliders; any slider position change is immediately applied to its mirror. The trigger position slider in the zoom view is inactive, it reflects relative position of the trigger within zoom window.

![screenshot from 2018-01-11 22-35-06](https://user-images.githubusercontent.com/11679699/34843500-ba2fc9a6-f71f-11e7-981a-8e6c7a271d8f.png)

Further enhancement could be adding 3rd view to DsoWidget:
- main scope & sliders only
- split view (the one we have now), both main and zoomed scopes are displayed
- zoom view (the new one), main scope & sliders are hidden.