### PR TITLE
OpenGL3/ES does not have anti-aliasing hints as before. 

### DIFF
--- a/openhantek/src/configdialog/DsoConfigScopePage.cpp
+++ b/openhantek/src/configdialog/DsoConfigScopePage.cpp
@@ -5,11 +5,9 @@
 DsoConfigScopePage::DsoConfigScopePage(DsoSettings *settings, QWidget *parent) : QWidget(parent), settings(settings) {
     // Initialize lists for comboboxes
     QStringList interpolationStrings;
-    interpolationStrings << tr("Off") << tr("Linear") << tr("Sinc");
+    interpolationStrings << tr("Off") << tr("Linear");
 
     // Initialize elements
-    antialiasingCheckBox = new QCheckBox(tr("Antialiasing"));
-    antialiasingCheckBox->setChecked(settings->view.antialiasing);
     interpolationLabel = new QLabel(tr("Interpolation"));
     interpolationComboBox = new QComboBox();
     interpolationComboBox->addItems(interpolationStrings);
@@ -21,7 +19,6 @@ DsoConfigScopePage::DsoConfigScopePage(DsoSettings *settings, QWidget *parent) :
     digitalPhosphorDepthSpinBox->setValue(settings->view.digitalPhosphorDepth);
 
     graphLayout = new QGridLayout();
-    graphLayout->addWidget(antialiasingCheckBox, 0, 0, 1, 2);
     graphLayout->addWidget(interpolationLabel, 1, 0);
     graphLayout->addWidget(interpolationComboBox, 1, 1);
     graphLayout->addWidget(digitalPhosphorDepthLabel, 2, 0);
@@ -39,7 +36,6 @@ DsoConfigScopePage::DsoConfigScopePage(DsoSettings *settings, QWidget *parent) :
 
 /// \brief Saves the new settings.
 void DsoConfigScopePage::saveSettings() {
-    settings->view.antialiasing = antialiasingCheckBox->isChecked();
     settings->view.interpolation = (Dso::InterpolationMode)interpolationComboBox->currentIndex();
     settings->view.digitalPhosphorDepth = digitalPhosphorDepthSpinBox->value();
 }

--- a/openhantek/src/configdialog/DsoConfigScopePage.h
+++ b/openhantek/src/configdialog/DsoConfigScopePage.h
@@ -33,7 +33,6 @@ class DsoConfigScopePage : public QWidget {
 
     QGroupBox *graphGroup;
     QGridLayout *graphLayout;
-    QCheckBox *antialiasingCheckBox;
     QLabel *digitalPhosphorDepthLabel;
     QSpinBox *digitalPhosphorDepthSpinBox;
     QLabel *interpolationLabel;

--- a/openhantek/src/glscope.cpp
+++ b/openhantek/src/glscope.cpp
@@ -20,8 +20,11 @@
 #include "viewconstants.h"
 #include "viewsettings.h"
 
-// typedef QOpenGLFunctions_ES2 OPENGL_VER;
+#if defined(QT_OPENGL_ES_2)
+typedef QOpenGLFunctions_ES2 OPENGL_VER;
+#else
 typedef QOpenGLFunctions_3_3_Core OPENGL_VER;
+#endif
 
 GlScope *GlScope::createNormal(DsoSettingsScope *scope, DsoSettingsView *view, QWidget *parent) {
     GlScope *s = new GlScope(scope, view, parent);
@@ -153,8 +156,6 @@ void GlScope::initializeGL() {
     gl->glEnable(GL_CULL_FACE);
     gl->glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
 
-    gl->glPointSize(1);
-
     QColor bg = view->screen.background;
     gl->glClearColor((GLfloat)bg.redF(), (GLfloat)bg.greenF(), (GLfloat)bg.blueF(), (GLfloat)bg.alphaF());
 
@@ -203,12 +204,6 @@ void GlScope::paintGL() {
 
     m_program->bind();
 
-    if (view->antialiasing) {
-        gl->glEnable(GL_POINT_SMOOTH);
-        gl->glEnable(GL_LINE_SMOOTH);
-        gl->glHint(GL_LINE_SMOOTH_HINT, GL_NICEST);
-    }
-
     // Apply zoom settings via matrix transformation
     if (zoomed) {
         QMatrix4x4 m;
@@ -226,9 +221,6 @@ void GlScope::paintGL() {
         }
         ++historyIndex;
     }
-
-    gl->glDisable(GL_POINT_SMOOTH);
-    gl->glDisable(GL_LINE_SMOOTH);
 
     if (zoomed) { m_program->setUniformValue(matrixLocation, pmvMatrix); }
 
@@ -258,8 +250,6 @@ void GlScope::resizeGL(int width, int height) {
 
 void GlScope::drawGrid() {
     auto *gl = context()->versionFunctions<OPENGL_VER>();
-    gl->glDisable(GL_POINT_SMOOTH);
-    gl->glDisable(GL_LINE_SMOOTH);
     gl->glLineWidth(1);
 
     // Grid

--- a/openhantek/src/main.cpp
+++ b/openhantek/src/main.cpp
@@ -75,6 +75,7 @@ int main(int argc, char *argv[]) {
     // Prefer full desktop OpenGL without fixed pipeline
     QSurfaceFormat format;
     format.setProfile(QSurfaceFormat::CoreProfile);
+    format.setSamples(4); // Antia-Aliasing, Multisampling
     QSurfaceFormat::setDefaultFormat(format);
     QApplication openHantekApplication(argc, argv);
 


### PR DESCRIPTION
We need to set a multisampling value at the beginning. Remove antialiasing from config dialog therefore.