### PR TITLE
Use OpenGL 3.2 instead of 3.3 to make MacOSX work again

### DIFF
--- a/openhantek/src/dsowidget.h
+++ b/openhantek/src/dsowidget.h
@@ -42,6 +42,7 @@ class DsoWidget : public QWidget {
     void showNew(std::shared_ptr<PPresult> data);
 
   protected:
+    virtual void showEvent(QShowEvent *event);
     void setupSliders(Sliders &sliders);
     void adaptTriggerLevelSlider(DsoWidget::Sliders &sliders, ChannelID channel);
     void adaptTriggerPositionSlider();

--- a/openhantek/src/glscope.h
+++ b/openhantek/src/glscope.h
@@ -31,10 +31,16 @@ class GlScope : public QOpenGLWidget {
                                  QWidget *parent = 0);
 
     /**
+     * We need at least OpenGL 3.2 with shader version 150 or
+     * OpenGL ES 2.0 with shader version 100.
+     */
+    static void fixOpenGLversion();
+    /**
      * Show new post processed data
      * @param data
      */
     void showData(PPresult* data);
+    void markerUpdated();
 
   protected:
     /// \brief Initializes the scope widget.
@@ -42,21 +48,23 @@ class GlScope : public QOpenGLWidget {
     /// \param parent The parent widget.
     GlScope(DsoSettingsScope *scope, DsoSettingsView *view, QWidget *parent = 0);
     virtual ~GlScope();
+    GlScope(const GlScope&) = delete;
 
     /// \brief Initializes OpenGL output.
-    void initializeGL() override;
+    virtual void initializeGL() override;
 
     /// \brief Draw the graphs, marker and the grid.
-    void paintGL() override;
+    virtual void paintGL() override;
 
     /// \brief Resize the widget.
     /// \param width The new width of the widget.
     /// \param height The new height of the widget.
-    void resizeGL(int width, int height) override;
+    virtual void resizeGL(int width, int height) override;
 
-    void mousePressEvent(QMouseEvent *event) override;
-    void mouseMoveEvent(QMouseEvent *event) override;
-    void mouseReleaseEvent(QMouseEvent *event) override;
+    virtual void mousePressEvent(QMouseEvent *event) override;
+    virtual void mouseMoveEvent(QMouseEvent *event) override;
+    virtual void mouseReleaseEvent(QMouseEvent *event) override;
+    virtual void paintEvent(QPaintEvent *event) override;
 
     /// \brief Draw the grid.
     void drawGrid();
@@ -91,13 +99,15 @@ class GlScope : public QOpenGLWidget {
     QOpenGLBuffer m_grid;
     QOpenGLVertexArrayObject m_vaoGrid[3];
     GLsizei gridDrawCounts[3];
-    void generateGrid();
+    void generateGrid(QOpenGLShaderProgram *program);
 
     // Graphs
     std::list<Graph> m_GraphHistory;
     unsigned currentGraphInHistory = 0;
 
     // OpenGL shader, matrix, var-locations
+    bool shaderCompileSuccess = false;
+    QString errorMessage;
     std::unique_ptr<QOpenGLShaderProgram> m_program;
     QMatrix4x4 pmvMatrix; ///< projection, view matrix
     int colorLocation;

--- a/openhantek/src/main.cpp
+++ b/openhantek/src/main.cpp
@@ -24,6 +24,8 @@
 #include "usb/usbdevice.h"
 #include "viewconstants.h"
 
+#include "glscope.h"
+
 #ifndef VERSION
 #error "You need to run the cmake buildsystem!"
 #endif
@@ -69,14 +71,8 @@ int main(int argc, char *argv[]) {
     QCoreApplication::setApplicationName("OpenHantek");
     QCoreApplication::setApplicationVersion(VERSION);
 
-    QCoreApplication::setAttribute(Qt::AA_UseOpenGLES, true);
-    QCoreApplication::setAttribute(Qt::AA_ShareOpenGLContexts, true);
+    GlScope::fixOpenGLversion();
 
-    // Prefer full desktop OpenGL without fixed pipeline
-    QSurfaceFormat format;
-    format.setProfile(QSurfaceFormat::CoreProfile);
-    format.setSamples(4); // Antia-Aliasing, Multisampling
-    QSurfaceFormat::setDefaultFormat(format);
     QApplication openHantekApplication(argc, argv);
 
     //////// Load translations ////////
@@ -155,5 +151,10 @@ int main(int argc, char *argv[]) {
 
     postProcessingThread.quit();
     postProcessingThread.wait(10000);
+
+    if (context && device != nullptr) {
+        libusb_exit(context);
+    }
+
     return res;
 }

--- a/openhantek/src/scopesettings.h
+++ b/openhantek/src/scopesettings.h
@@ -11,6 +11,7 @@
 #include <vector>
 
 #define MARKER_COUNT 2 ///< Number of markers
+#define MARKER_STEP (DIVS_TIME / 100.0)
 
 /// \brief Holds the settings for the horizontal axis.
 struct DsoSettingsScopeHorizontal {

--- a/openhantek/src/widgets/levelslider.cpp
+++ b/openhantek/src/widgets/levelslider.cpp
@@ -196,17 +196,14 @@ double LevelSlider::maximum(int index) const {
 /// \param minimum The value a slider has at the bottommost/leftmost position.
 /// \param maximum The value a slider has at the topmost/rightmost position.
 /// \return -1 on error, fixValue result on success.
-int LevelSlider::setLimits(int index, double minimum, double maximum) {
-    if (index < 0 || index >= this->slider.count()) return -1;
+void LevelSlider::setLimits(int index, double minimum, double maximum) {
+    if (index < 0 || index >= this->slider.count()) return;
 
     this->slider[index]->minimum = minimum;
     this->slider[index]->maximum = maximum;
-    int result = this->fixValue(index);
-
+    this->fixValue(index);
     this->calculateRect(index);
     this->repaint();
-
-    return result;
 }
 
 /// \brief Return the step width of the sliders.
@@ -243,8 +240,8 @@ double LevelSlider::value(int index) const {
 /// \param index The index of the slider whose value should be set.
 /// \param value The new value of the slider.
 /// \return The new value of the slider.
-double LevelSlider::setValue(int index, double value) {
-    if (index < 0 || index >= this->slider.count()) return -1;
+void LevelSlider::setValue(int index, double value) {
+    if (index < 0 || index >= this->slider.count()) return;
 
     // Apply new value
     this->slider[index]->value = value;
@@ -254,8 +251,6 @@ double LevelSlider::setValue(int index, double value) {
     this->repaint();
 
     if (this->pressedSlider < 0) emit valueChanged(index, value);
-
-    return this->slider[index]->value;
 }
 
 /// \brief Return the direction of the sliders.
@@ -563,17 +558,14 @@ int LevelSlider::calculateWidth() {
 /// \brief Fix the value if it's outside the limits.
 /// \param index The index of the slider who should be fixed.
 /// \return 0 when ok, -1 on error, 1 when increased and 2 when decreased.
-int LevelSlider::fixValue(int index) {
-    if (index < 0 || index >= this->slider.count()) return -1;
+void LevelSlider::fixValue(int index) {
+    if (index < 0 || index >= this->slider.count()) return;
 
     double lowest = qMin(this->slider[index]->minimum, this->slider[index]->maximum);
     double highest = qMax(this->slider[index]->minimum, this->slider[index]->maximum);
     if (this->slider[index]->value < lowest) {
         this->slider[index]->value = lowest;
-        return 1;
     } else if (this->slider[index]->value > highest) {
         this->slider[index]->value = highest;
-        return 2;
     }
-    return 0;
 }

--- a/openhantek/src/widgets/levelslider.h
+++ b/openhantek/src/widgets/levelslider.h
@@ -51,11 +51,11 @@ class LevelSlider : public QWidget {
 
     double minimum(int index) const;
     double maximum(int index) const;
-    int setLimits(int index, double minimum, double maximum);
+    void setLimits(int index, double minimum, double maximum);
     double step(int index) const;
     double setStep(int index, double step);
     double value(int index) const;
-    double setValue(int index, double value);
+    void setValue(int index, double value);
 
     // Parameters for all sliders
     Qt::ArrowType direction() const;
@@ -71,7 +71,7 @@ class LevelSlider : public QWidget {
 
     QRect calculateRect(int sliderId);
     int calculateWidth();
-    int fixValue(int index);
+    void fixValue(int index);
 
     QList<LevelSliderParameters *> slider; ///< The parameters for each slider
     int pressedSlider;                     ///< The currently pressed (moved) slider


### PR DESCRIPTION
Fix:
* Move all GL startup calls to GLScope::fixOpenGLversion
* Depending on OpenGL or ES availability initialize the QSurfaceFormat
* Don't crash if the shader compilation failed. Show a nice message instead.
* Use DsoWidget::showEvent to update all kind of UI things. Otherwise 
  for example the zoom view potentially will be "shown" (setVisible), before the DsoWidget
  finished its constructor and we get multiple `initializeGL()` calls.

Optimize:
* Don't write the markers to the GPU each frame update, only
  do this if they actually changed position.

Code style:
* LevelSlider: Don't return a value for set* Methods.
* Don't rely on the LevelSliders step to calculate the marker position in the OpenGL view.

Fixes #154 
Fixes #155