### PR TITLE
Auto-detect OpenGL version compatibility

### DIFF
--- a/openhantek/src/main.cpp
+++ b/openhantek/src/main.cpp
@@ -84,9 +84,9 @@ int main(int argc, char *argv[]) {
         useGles = p.isSet(useGlesOption);
     }
 
-    GlScope::fixOpenGLversion(useGles ? QSurfaceFormat::OpenGLES : QSurfaceFormat::OpenGL);
-
     QApplication openHantekApplication(argc, argv);
+
+    GlScope::fixOpenGLversion(useGles ? QSurfaceFormat::OpenGLES : QSurfaceFormat::OpenGL);
 
     //////// Load translations ////////
     QTranslator qtTranslator;


### PR DESCRIPTION
@davidgraeff This is an enhancement for **switchgl** branch that enables auto-detection of OpenGL version. Version 3.2 and higher compiles version 1.5 shaders. All lower OpenGL versions fall back to OpenGL ES format (supposed to be compatible with version 1.0 shaders).

My HP 8440p laptop + Ubuntu Studio 17.10:
```
$ glxinfo | grep OpenGL
OpenGL vendor string: Intel Open Source Technology Center
OpenGL renderer string: Mesa DRI Intel(R) Ironlake Mobile 
OpenGL version string: 2.1 Mesa 17.2.2
OpenGL shading language version string: 1.20
OpenGL extensions:
OpenGL ES profile version string: OpenGL ES 2.0 Mesa 17.2.2
OpenGL ES profile shading language version string: OpenGL ES GLSL ES 1.0.16
OpenGL ES profile extensions:
```