### PR TITLE
GlScope: Use offscreen buffers to realize the phosphor effect

### DIFF
--- a/openhantek/src/glscope.h
+++ b/openhantek/src/glscope.h
@@ -20,6 +20,10 @@ struct DsoSettingsView;
 struct DsoSettingsScope;
 class PPresult;
 
+class GlScopeGridAndMarkers {
+
+};
+
 /// \brief OpenGL accelerated widget that displays the oscilloscope screen.
 class GlScope : public QOpenGLWidget {
     Q_OBJECT
@@ -66,13 +70,12 @@ class GlScope : public QOpenGLWidget {
     virtual void mouseReleaseEvent(QMouseEvent *event) override;
     virtual void paintEvent(QPaintEvent *event) override;
 
+    inline GlScopeGridAndMarkers* gridAndMarkers() { return mGridAndMarkers; }
+
     /// \brief Draw the grid.
     void drawGrid();
     /// Draw vertical lines at marker positions
     void drawMarkers();
-
-    void drawVoltageChannelGraph(ChannelID channel, Graph &graph, int historyIndex);
-    void drawSpectrumChannelGraph(ChannelID channel, Graph &graph, int historyIndex);
   signals:
     void markerMoved(unsigned marker, double position);
 
@@ -92,8 +95,8 @@ class GlScope : public QOpenGLWidget {
     #pragma pack(pop)
     std::vector<Line> vaMarker;
     unsigned selectedMarker = NO_MARKER;
-    QOpenGLBuffer m_marker;
-    QOpenGLVertexArrayObject m_vaoMarker;
+    QOpenGLBuffer markerVBO;
+    QOpenGLVertexArrayObject markerVAO;
 
     // Grid
     QOpenGLBuffer m_grid;
@@ -108,7 +111,10 @@ class GlScope : public QOpenGLWidget {
     // OpenGL shader, matrix, var-locations
     bool shaderCompileSuccess = false;
     QString errorMessage;
-    std::unique_ptr<QOpenGLShaderProgram> m_program;
+    std::unique_ptr<QOpenGLShaderProgram> shaderProgramColor;
+    std::unique_ptr<QOpenGLShaderProgram> shaderProgramTexture;
+    QOpenGLBuffer fullscreenVBO;
+    QOpenGLVertexArrayObject fullscreenVAO;
     QMatrix4x4 pmvMatrix; ///< projection, view matrix
     int colorLocation;
     int vertexLocation;

--- a/openhantek/src/glscopegraph.cpp
+++ b/openhantek/src/glscopegraph.cpp
@@ -1,19 +1,33 @@
 #include "glscopegraph.h"
+#include "viewsettings.h"
 #include <QDebug>
+#include <QImage>
 
 Graph::Graph() : buffer(QOpenGLBuffer::VertexBuffer) {
-    buffer.create();
-    buffer.setUsagePattern(QOpenGLBuffer::DynamicDraw);
+    moveToThread(&thread);
+    thread.start();
 }
 
-void Graph::writeData(PPresult *data, QOpenGLShaderProgram *program, int vertexLocation) {
+void Graph::draw() {
+    if (!buffer.isCreated()) return;
+
+    QWriteLocker locker(&lock);
+
     // Determine memory
     int neededMemory = 0;
     for (ChannelGraph &cg : data->vaChannelVoltage) neededMemory += cg.size() * sizeof(QVector3D);
     for (ChannelGraph &cg : data->vaChannelSpectrum) neededMemory += cg.size() * sizeof(QVector3D);
 
+    context->makeCurrent(&offscreen);
+    auto *gl = context->functions();
+    fbo->bind();
     buffer.bind();
     program->bind();
+
+    gl->glViewport(0, 0, size.width(), size.height());
+    gl->glClearColor(0.12, 0.12, 0.12, 1.0);
+    gl->glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
+    gl->glLineWidth(1);
 
     // Allocate space if necessary
     if (neededMemory > allocatedMem) {
@@ -21,61 +35,130 @@ void Graph::writeData(PPresult *data, QOpenGLShaderProgram *program, int vertexL
         allocatedMem = neededMemory;
     }
 
+    const GLenum dMode = (view->interpolation == Dso::INTERPOLATION_OFF) ? GL_POINTS : GL_LINE_STRIP;
+
     // Write data to buffer
     int offset = 0;
-    vaoVoltage.resize(data->vaChannelVoltage.size());
-    vaoSpectrum.resize(data->vaChannelSpectrum.size());
-    for (ChannelID channel = 0; channel < vaoVoltage.size(); ++channel) {
+
+    for (ChannelID channel = 0; channel < data->vaChannelVoltage.size(); ++channel) {
         int dataSize;
 
-        // Voltage channel
-        if (channel < vaoVoltage.size()) {
-            VaoCount &v = vaoVoltage[channel];
-            if (!v.first) {
-                v.first = new QOpenGLVertexArrayObject;
-                if (!v.first->create()) throw new std::runtime_error("QOpenGLVertexArrayObject create failed");
-            }
-            ChannelGraph &gVoltage = data->vaChannelVoltage[channel];
-            v.first->bind();
-            dataSize = int(gVoltage.size() * sizeof(QVector3D));
-            buffer.write(offset, gVoltage.data(), dataSize);
-            program->enableAttributeArray(vertexLocation);
-            program->setAttributeBuffer(vertexLocation, GL_FLOAT, offset, 3, 0);
-            v.first->release();
-            v.second = (int)gVoltage.size();
-            offset += dataSize;
-        }
+        ChannelGraph &gVoltage = data->vaChannelVoltage[channel];
+
+        dataSize = int(gVoltage.size() * sizeof(QVector3D));
+        buffer.write(offset, gVoltage.data(), dataSize);
+        program->enableAttributeArray(vertexLocation);
+        program->setAttributeBuffer(vertexLocation, GL_FLOAT, offset, 3, 0);
+
+        program->setUniformValue(colorLocation, view->screen.voltage[channel]);
+        context->functions()->glDrawArrays(dMode, 0, (int)gVoltage.size());
+
+        offset += dataSize;
 
         // Spectrum channel
+
         if (channel < vaoSpectrum.size()) {
-            VaoCount &s = vaoSpectrum[channel];
-            if (!s.first) {
-                s.first = new QOpenGLVertexArrayObject;
-                if (!s.first->create()) throw new std::runtime_error("QOpenGLVertexArrayObject create failed");
-            }
             ChannelGraph &gSpectrum = data->vaChannelSpectrum[channel];
-            s.first->bind();
             dataSize = int(gSpectrum.size() * sizeof(QVector3D));
             buffer.write(offset, gSpectrum.data(), dataSize);
             program->enableAttributeArray(vertexLocation);
             program->setAttributeBuffer(vertexLocation, GL_FLOAT, offset, 3, 0);
-            s.first->release();
-            s.second = (int)gSpectrum.size();
+
+            program->setUniformValue(colorLocation, view->screen.spectrum[channel]);
+            context->functions()->glDrawArrays(dMode, 0, (int)gSpectrum.size());
+
             offset += dataSize;
         }
     }
 
     buffer.release();
+
+    // Multisampling supported. We need a final fbo to blit from the render target fbo,
+    // to get an OpenGL texture.
+    if (fbo->format().samples() > 0) {
+        fboFinal->bind();
+        QOpenGLFramebufferObject::blitFramebuffer(fboFinal, fbo);
+    }
+    ready = true;
+
+    gl->glFlush();
+
+    qWarning() << "normal" << fbo->width() << fbo->height() << fbo->format().samples();
+    qWarning() << "final" << fboFinal->width() << fboFinal->height() << fboFinal->format().samples();
+    fboFinal->toImage().save("/home/david/build-openhantek-clang-Debug/out.png");
+    emit fboReady();
+}
+
+void Graph::createInThread() {
+    QOpenGLContext *global = this->context;
+    this->context = new QOpenGLContext(this);
+    this->context->setFormat(global->format());
+    this->context->setShareContext(global);
+    if (!this->context->create()) {
+        qWarning() << "Couldn't create context for scope graph";
+        return;
+    }
+    this->context->makeCurrent(&offscreen);
+
+    if (!buffer.create()) {
+        qWarning() << "Couldn't create buffer for scope graph";
+        return;
+    }
+    buffer.setUsagePattern(QOpenGLBuffer::DynamicDraw);
+
+    QOpenGLFramebufferObjectFormat format;
+    format.setAttachment(QOpenGLFramebufferObject::CombinedDepthStencil);
+    format.setSamples(4);
+    format.setSamples(0); // TODO remove
+    fbo = new QOpenGLFramebufferObject(size.width(), size.height(), format);
+    if (fbo->format().samples() > 0) {
+        // Multisampling supported. We need a final fbo to blit from the render target fbo,
+        // to get an OpenGL texture.
+        QOpenGLFramebufferObjectFormat format;
+        format.setSamples(0);
+        fboFinal = new QOpenGLFramebufferObject(size.width(), size.height(), format);
+    } else {
+        // No multisampling supported, the final fbo is the same as the render target fbo
+        fboFinal = fbo;
+    }
 }
 
 Graph::~Graph() {
-    for (auto &vao : vaoVoltage) {
-        vao.first->destroy();
-        delete vao.first;
+    thread.quit();
+    destroy();
+}
+
+void Graph::create(const QRect &size, QOpenGLShaderProgram *program, QOpenGLContext *context, DsoSettingsView *view,
+                   int vertexLocation, int colorLocation) {
+    this->program = program;
+    this->vertexLocation = vertexLocation;
+    this->colorLocation = colorLocation;
+    this->view = view;
+    this->size = size;
+    this->context = context;
+    offscreen.setFormat(context->surface()->format());
+    offscreen.create();
+
+    QMetaObject::invokeMethod(this, "createInThread", Qt::QueuedConnection);
+}
+
+void Graph::destroy() {
+    delete fboFinal;
+    if (fboFinal != fbo) delete fbo;
+    fbo = nullptr;
+    fboFinal = nullptr;
+
+    if (offscreen.isValid()) offscreen.destroy();
+    if (buffer.isCreated()) buffer.destroy();
+
+    delete context;
+}
+
+void Graph::redraw() {
+    if (!buffer.isCreated()) {
+        qWarning() << "writeData executed on a Graph object that has not been initalized!";
+        return;
     }
-    for (auto &vao : vaoSpectrum) {
-        vao.first->destroy();
-        delete vao.first;
-    }
-    if (buffer.isCreated()) { buffer.destroy(); }
+    QMetaObject::invokeMethod(this, "draw", Qt::QueuedConnection);
+    ;
 }

--- a/openhantek/src/glscopegraph.h
+++ b/openhantek/src/glscopegraph.h
@@ -1,27 +1,96 @@
+// SPDX-License-Identifier: GPL-2.0+
+
 #pragma once
 
 #include <memory>
 
+#include <QMutex>
+#include <QOffscreenSurface>
 #include <QOpenGLBuffer>
+#include <QOpenGLFramebufferObject>
 #include <QOpenGLFunctions>
 #include <QOpenGLShaderProgram>
 #include <QOpenGLVertexArrayObject>
-#include <QOpenGLWidget>
+#include <QReadWriteLock>
+#include <QThread>
 #include <QtGlobal>
 
 #include "post/ppresult.h"
 
-struct Graph {
+struct DsoSettingsView;
+
+/**
+ * A graph object represents one sample snaptshot with all channels
+ * visualized on an OpenGL offscreen surface.
+ */
+class Graph : public QObject {
+    Q_OBJECT
+  public:
     explicit Graph();
-    Graph(const Graph &) = delete;
-    Graph(const Graph &&) = delete;
+    /// Calls destroy() internally
     ~Graph();
-    void writeData(PPresult *data, QOpenGLShaderProgram *program, int vertexLocation);
-    typedef std::pair<QOpenGLVertexArrayObject *, GLsizei> VaoCount;
+
+    /**
+     * Allocate necessary resources and assign required parameters
+     * @param size
+     * @param program
+     * @param context
+     * @param view
+     * @param vertexLocation
+     * @param colorLocation
+     */
+    void create(const QRect &size, QOpenGLShaderProgram *program, QOpenGLContext *context, DsoSettingsView *view,
+                int vertexLocation, int colorLocation);
+
+    /// Deallocate resources. Can be called multiple times.
+    void destroy();
+
+    /// Will queue a draw request to the worker thread queue.
+    void redraw();
+
+    /// Return true if the framebuffer is created and was drawn at least once
+    inline bool isReady() { return ready; }
+
+    /// Return the framebuffer
+    inline QOpenGLFramebufferObject *getFBO() { return fboFinal; }
+
+    /// Return the read/write lock of this graph. You should always aquire a read lock
+    /// before operating on the framebuffer of this graph object.
+    inline QReadWriteLock *getLock() { return &lock; }
+
+    /// Assign new data to the graph. You need to call redraw() as well.
+    inline void assignData(std::shared_ptr<PPresult> &data) { this->data = data; }
 
   public:
+    Graph(const Graph &) = delete;
+    Graph(const Graph &&) = delete;
+
+  private slots:
+    void createInThread();
+    void draw();
+
+  signals:
+    void fboReady();
+
+  private:
+    // Threading
+    QReadWriteLock lock;
+    QThread thread;
+
+    // Data
+    std::shared_ptr<PPresult> data;
+    QRect size;
+    DsoSettingsView *view;
+
+    // OpenGL buffers
+    bool ready = false;
     int allocatedMem = 0;
     QOpenGLBuffer buffer;
-    std::vector<VaoCount> vaoVoltage;
-    std::vector<VaoCount> vaoSpectrum;
+    QOpenGLFramebufferObject *fbo;
+    QOpenGLFramebufferObject *fboFinal;
+    QOpenGLShaderProgram *program;
+    QOpenGLContext *context;
+    QOffscreenSurface offscreen;
+    int vertexLocation;
+    int colorLocation;
 };


### PR DESCRIPTION
## Current situation
At the moment if the phosphor effect is enabled, we redraw all graphs for every frame. This is a quite expensive operation because all generated vertices will be written to the GPU for every channel separately, no matter if they are present or not. If a marker is moved, this can slow down the GUI thread considerably.

## Change
The GlScopeGraph class plays a bigger role now and not only manages a GPU buffer for a sample snapshot but also draws everything to an offscreen buffer in a separate worker thread. Only once.

* The main GUI thread will not be blocked by the expensive GPU copy process, which now even takes place in parallel.
* It's easy now to detect skipped frames if the data comes in too fast.
* If the markers are used and a repaint is required, the channel graphs only need to be blit from the offscreen buffer to the main buffer. It almost doesn't matter anymore how many digital phosphor levels the user has set up.

## ToDo:
* Show a message to the user if a frame needs to be skipped
* Use one worker thread and one OpenGL context for all offscreen buffers and not as many threads as the user has digital phosphor levels. (The raspberry pi for instance will be overwhelmed by 8 threads for 8 levels).
* Add another shader program as a copy of the original one for the worker thread. Apparently a shader program is coupled to an OpenGL context, so we need a copy.
* Add another shader program to draw the offscreen texture to the main surface.
* Move all create/draw marker/grid functionality out of GlScope to a separate class. That way it can be reused by the exporter, exactly like GlScopeGraph can already be used.