### PR TITLE
Cursor measurements

### DIFF
--- a/openhantek/src/configdialog/DsoConfigScopePage.cpp
+++ b/openhantek/src/configdialog/DsoConfigScopePage.cpp
@@ -27,8 +27,22 @@ DsoConfigScopePage::DsoConfigScopePage(DsoSettings *settings, QWidget *parent) :
     graphGroup = new QGroupBox(tr("Graph"));
     graphGroup->setLayout(graphLayout);
 
+    cursorsLabel = new QLabel(tr("Position"));
+    cursorsComboBox = new QComboBox();
+    cursorsComboBox->addItem("Left", Qt::LeftToolBarArea);
+    cursorsComboBox->addItem("Right", Qt::RightToolBarArea);
+    cursorsComboBox->setCurrentIndex(settings->view.cursorGridPosition == Qt::LeftToolBarArea ? 0 : 1);
+
+    cursorsLayout = new QGridLayout();
+    cursorsLayout->addWidget(cursorsLabel, 0, 0);
+    cursorsLayout->addWidget(cursorsComboBox, 0, 1);
+
+    cursorsGroup = new QGroupBox(tr("Cursors"));
+    cursorsGroup->setLayout(cursorsLayout);
+
     mainLayout = new QVBoxLayout();
     mainLayout->addWidget(graphGroup);
+    mainLayout->addWidget(cursorsGroup);
     mainLayout->addStretch(1);
 
     setLayout(mainLayout);
@@ -38,4 +52,5 @@ DsoConfigScopePage::DsoConfigScopePage(DsoSettings *settings, QWidget *parent) :
 void DsoConfigScopePage::saveSettings() {
     settings->view.interpolation = (Dso::InterpolationMode)interpolationComboBox->currentIndex();
     settings->view.digitalPhosphorDepth = digitalPhosphorDepthSpinBox->value();
+    settings->view.cursorGridPosition = (Qt::ToolBarArea)cursorsComboBox->currentData().toUInt();
 }

--- a/openhantek/src/configdialog/DsoConfigScopePage.h
+++ b/openhantek/src/configdialog/DsoConfigScopePage.h
@@ -37,4 +37,9 @@ class DsoConfigScopePage : public QWidget {
     QSpinBox *digitalPhosphorDepthSpinBox;
     QLabel *interpolationLabel;
     QComboBox *interpolationComboBox;
+
+    QGroupBox *cursorsGroup;
+    QGridLayout *cursorsLayout;
+    QLabel *cursorsLabel;
+    QComboBox *cursorsComboBox;
 };

--- a/openhantek/src/dsowidget.cpp
+++ b/openhantek/src/dsowidget.cpp
@@ -147,14 +147,13 @@ DsoWidget::DsoWidget(DsoSettingsScope *scope, DsoSettingsView *view, const Dso::
 
     // Cursors
     cursorDataGrid = new DataGrid(this);
-    cursorDataGrid->addItem(tr("Markers"), view->screen.background, view->screen.text);
+    cursorDataGrid->setBackgroundColor(view->screen.background);
+    cursorDataGrid->addItem(tr("Markers"), view->screen.text);
     for (ChannelID channel = 0; channel < scope->voltage.size(); ++channel) {
-        cursorDataGrid->addItem(scope->voltage[channel].name, view->screen.background,
-                                view->screen.voltage[channel]);
+        cursorDataGrid->addItem(scope->voltage[channel].name, view->screen.voltage[channel]);
     }
     for (ChannelID channel = 0; channel < scope->spectrum.size(); ++channel) {
-        cursorDataGrid->addItem(scope->spectrum[channel].name, view->screen.background,
-                                view->screen.spectrum[channel]);
+        cursorDataGrid->addItem(scope->spectrum[channel].name, view->screen.spectrum[channel]);
     }
     cursorDataGrid->selectItem(0);
 

--- a/openhantek/src/dsowidget.h
+++ b/openhantek/src/dsowidget.h
@@ -15,10 +15,7 @@
 class SpectrumGenerator;
 struct DsoSettingsScope;
 struct DsoSettingsView;
-
-class QPushButton;
-class QGroupBox;
-class QButtonGroup;
+class DataGrid;
 
 /// \brief The widget for the oszilloscope-screen
 /// This widget contains the scopes and all level sliders.
@@ -32,18 +29,6 @@ class DsoWidget : public QWidget {
         LevelSlider *triggerPositionSlider; ///< The slider for the pretrigger
         LevelSlider *triggerLevelSlider;    ///< The sliders for the trigger level
         LevelSlider *markerSlider;          ///< The sliders for the markers
-    };
-
-    struct CursorInfo {
-        int index = -1;         ///< The position in QButtonGroup
-        QPushButton *selector;  ///< The name of the channel
-        QPushButton *shape;     ///< The cursor shape
-        QLabel *deltaXLabel;    ///< The horizontal distance between cursors
-        QLabel *deltaYLabel;    ///< The vertical distance between cursors
-
-        CursorInfo();
-        void configure(const QString &text, const QColor &bgColor, const QColor &fgColor);
-        void setupLayout(QGridLayout *layout, unsigned row);
     };
 
     /// \brief Initializes the components of the oszilloscope-screen.
@@ -99,12 +84,7 @@ class DsoWidget : public QWidget {
     std::vector<QLabel *> measurementAmplitudeLabel; ///< Amplitude of the signal (V)
     std::vector<QLabel *> measurementFrequencyLabel; ///< Frequency of the signal (Hz)
 
-    QGroupBox *cursorsGroupBox;
-    QButtonGroup *cursorsSelectorGroup;
-    QGridLayout *cursorsLayout;                 ///< The table for the cursor parameters
-    CursorInfo markerInfo;                      ///< The cursor info for horizontal axis markers
-    std::vector<CursorInfo> voltageCursors;     ///< The cursor info for voltage channels
-    std::vector<CursorInfo> spectrumCursors;    ///< The cursor info for spectrum channels
+    DataGrid *cursorDataGrid;
 
     DsoSettingsScope* scope;
     DsoSettingsView* view;

--- a/openhantek/src/dsowidget.h
+++ b/openhantek/src/dsowidget.h
@@ -16,10 +16,16 @@ class SpectrumGenerator;
 struct DsoSettingsScope;
 struct DsoSettingsView;
 
+class QPushButton;
+class QGroupBox;
+class QButtonGroup;
+
 /// \brief The widget for the oszilloscope-screen
 /// This widget contains the scopes and all level sliders.
 class DsoWidget : public QWidget {
     Q_OBJECT
+
+  public:
 
     struct Sliders {
         LevelSlider *offsetSlider;          ///< The sliders for the graph offsets
@@ -28,7 +34,18 @@ class DsoWidget : public QWidget {
         LevelSlider *markerSlider;          ///< The sliders for the markers
     };
 
-  public:
+    struct CursorInfo {
+        int index = -1;         ///< The position in QButtonGroup
+        QPushButton *selector;  ///< The name of the channel
+        QPushButton *shape;     ///< The cursor shape
+        QLabel *deltaXLabel;    ///< The horizontal distance between cursors
+        QLabel *deltaYLabel;    ///< The vertical distance between cursors
+
+        CursorInfo();
+        void configure(const QString &text, const QColor &bgColor, const QColor &fgColor);
+        void setupLayout(QGridLayout *layout, unsigned row);
+    };
+
     /// \brief Initializes the components of the oszilloscope-screen.
     /// \param settings The settings object containing the oscilloscope settings.
     /// \param dataAnalyzer The data analyzer that should be used as data source.
@@ -49,6 +66,9 @@ class DsoWidget : public QWidget {
     void updateSpectrumDetails(ChannelID channel);
     void updateTriggerDetails();
     void updateVoltageDetails(ChannelID channel);
+
+    double mainToZoom(double position) const;
+    double zoomToMain(double position) const;
 
     Sliders mainSliders;
     Sliders zoomSliders;
@@ -78,6 +98,13 @@ class DsoWidget : public QWidget {
     std::vector<QLabel *> measurementMiscLabel;      ///< Coupling or math mode
     std::vector<QLabel *> measurementAmplitudeLabel; ///< Amplitude of the signal (V)
     std::vector<QLabel *> measurementFrequencyLabel; ///< Frequency of the signal (Hz)
+
+    QGroupBox *cursorsGroupBox;
+    QButtonGroup *cursorsSelectorGroup;
+    QGridLayout *cursorsLayout;                 ///< The table for the cursor parameters
+    CursorInfo markerInfo;                      ///< The cursor info for horizontal axis markers
+    std::vector<CursorInfo> voltageCursors;     ///< The cursor info for voltage channels
+    std::vector<CursorInfo> spectrumCursors;    ///< The cursor info for spectrum channels
 
     DsoSettingsScope* scope;
     DsoSettingsView* view;
@@ -113,11 +140,12 @@ class DsoWidget : public QWidget {
 
     // Scope control
     void updateZoom(bool enabled);
+    void updateCursorGrid(bool enabled);
 
   private slots:
     // Sliders
     void updateOffset(ChannelID channel, double value);
-    void updateTriggerPosition(int index, double value);
+    void updateTriggerPosition(int index, double value, bool mainView = true);
     void updateTriggerLevel(ChannelID channel, double value);
     void updateMarker(int marker, double value);
 
@@ -126,5 +154,4 @@ class DsoWidget : public QWidget {
     void offsetChanged(ChannelID channel, double value);       ///< A graph offset has been changed
     void triggerPositionChanged(double value);                    ///< The pretrigger has been changed
     void triggerLevelChanged(ChannelID channel, double value); ///< A trigger level has been changed
-    void markerChanged(unsigned int marker, double value);        ///< A marker position has been changed
 };

--- a/openhantek/src/exporting/legacyexportdrawer.cpp
+++ b/openhantek/src/exporting/legacyexportdrawer.cpp
@@ -115,10 +115,12 @@ bool LegacyExportDrawer::exportSamples(const PPresult *result, QPaintDevice* pai
         painter.setPen(colorValues->text);
 
         // Calculate variables needed for zoomed scope
-        double divs = fabs(settings->scope.horizontal.marker[1] - settings->scope.horizontal.marker[0]);
+        double m1 = settings->scope.getMarker(0);
+        double m2 = settings->scope.getMarker(1);
+        double divs = fabs(m2 - m1);
         double time = divs * settings->scope.horizontal.timebase;
         double zoomFactor = DIVS_TIME / divs;
-        double zoomOffset = (settings->scope.horizontal.marker[0] + settings->scope.horizontal.marker[1]) / 2;
+        double zoomOffset = (m1 + m2) / 2;
 
         if (settings->view.zoom) {
             scopeHeight = (double)(paintDevice->height() - (channelCount + 5) * lineHeight) / 2;

--- a/openhantek/src/mainwindow.cpp
+++ b/openhantek/src/mainwindow.cpp
@@ -39,6 +39,7 @@ MainWindow::MainWindow(HantekDsoControl *dsoControl, DsoSettings *settings, Expo
     ui->actionManualCommand->setIcon(iconFont->icon(fa::edit));
     ui->actionDigital_phosphor->setIcon(QIcon(":/images/digitalphosphor.svg"));
     ui->actionZoom->setIcon(iconFont->icon(fa::crop));
+    ui->actionCursors->setIcon(iconFont->icon(fa::crosshairs));
 
     // Window title
     setWindowIcon(QIcon(":openhantek.png"));
@@ -160,6 +161,7 @@ MainWindow::MainWindow(HantekDsoControl *dsoControl, DsoSettings *settings, Expo
     auto usedChanged = [this, dsoControl, spec](ChannelID channel, bool used) {
         if (channel >= (unsigned int)mSettings->scope.voltage.size()) return;
 
+//        if (!used) dsoWidget->
         bool mathUsed = mSettings->scope.anyUsed(spec->channels);
 
         // Normal channel, check if voltage/spectrum or math channel is used
@@ -266,6 +268,18 @@ MainWindow::MainWindow(HantekDsoControl *dsoControl, DsoSettings *settings, Expo
         this->dsoWidget->updateZoom(enabled);
     });
     ui->actionZoom->setChecked(mSettings->view.zoom);
+
+    connect(ui->actionCursors, &QAction::toggled, [this](bool enabled) {
+        mSettings->view.cursorsVisible = enabled;
+
+        if (mSettings->view.cursorsVisible)
+            this->ui->actionCursors->setStatusTip(tr("Hide measurements"));
+        else
+            this->ui->actionCursors->setStatusTip(tr("Show measurements"));
+
+        this->dsoWidget->updateCursorGrid(enabled);
+    });
+    ui->actionCursors->setChecked(mSettings->view.cursorsVisible);
 
     connect(ui->actionAbout, &QAction::triggered, [this]() {
         QMessageBox::about(

--- a/openhantek/src/mainwindow.ui
+++ b/openhantek/src/mainwindow.ui
@@ -20,7 +20,7 @@
      <x>0</x>
      <y>0</y>
      <width>800</width>
-     <height>25</height>
+     <height>28</height>
     </rect>
    </property>
    <widget class="QMenu" name="menuFile">
@@ -39,6 +39,8 @@
     </property>
     <addaction name="actionDigital_phosphor"/>
     <addaction name="actionZoom"/>
+    <addaction name="actionCursors"/>
+    <addaction name="separator"/>
     <addaction name="actionManualCommand"/>
    </widget>
    <widget class="QMenu" name="menuOscilloscope">
@@ -84,6 +86,7 @@
    <addaction name="separator"/>
    <addaction name="actionDigital_phosphor"/>
    <addaction name="actionZoom"/>
+   <addaction name="actionCursors"/>
    <addaction name="separator"/>
   </widget>
   <action name="actionOpen">
@@ -165,6 +168,14 @@
    </property>
    <property name="text">
     <string>Manual command</string>
+   </property>
+  </action>
+  <action name="actionCursors">
+   <property name="checkable">
+    <bool>true</bool>
+   </property>
+   <property name="text">
+    <string>Cursors</string>
    </property>
   </action>
  </widget>

--- a/openhantek/src/viewsettings.h
+++ b/openhantek/src/viewsettings.h
@@ -42,6 +42,8 @@ struct DsoSettingsView {
     Dso::InterpolationMode interpolation = Dso::INTERPOLATION_LINEAR; ///< Interpolation mode for the graph
     bool screenColorImages = false;                                   ///< true exports images with screen colors
     bool zoom = false;                                                ///< true if the magnified scope is enabled
+    Qt::ToolBarArea cursorGridPosition = Qt::RightToolBarArea;
+    bool cursorsVisible = false;
 
     unsigned digitalPhosphorDraws() const {
         return digitalPhosphor ? digitalPhosphorDepth : 1;

--- a/openhantek/src/widgets/datagrid.cpp
+++ b/openhantek/src/widgets/datagrid.cpp
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: GPL-2.0+
+
 #include "datagrid.h"
 
 #include <QGridLayout>
@@ -32,6 +34,9 @@ DataGrid::CursorInfo::CursorInfo() {
 }
 
 void DataGrid::CursorInfo::configure(const QString &text, const QColor &bgColor, const QColor &fgColor) {
+    palette.setColor(QPalette::Background, bgColor);
+    palette.setColor(QPalette::WindowText, fgColor);
+
     selector->setText(text);
     selector->setStyleSheet(QString(R"(
         QPushButton {
@@ -60,19 +65,29 @@ void DataGrid::CursorInfo::configure(const QString &text, const QColor &bgColor,
     )").arg(bgColor.name(QColor::HexArgb))
        .arg(fgColor.name(QColor::HexArgb)));
 
-    QPalette palette;
-    palette.setColor(QPalette::Background, bgColor);
-    palette.setColor(QPalette::WindowText, fgColor);
     deltaXLabel->setPalette(palette);
-    deltaYLabel->setPalette(palette);   
+    deltaYLabel->setPalette(palette);
 }
 
-unsigned DataGrid::addItem(const QString &text, const QColor &bgColor, const QColor &fgColor) {
+void DataGrid::setBackgroundColor(const QColor &bgColor) {
+    backgroundColor = bgColor;
+    for (auto it : items) {
+        it.configure(it.selector->text(), bgColor, it.palette.color(QPalette::WindowText));
+    }
+}
+
+void DataGrid::configureItem(unsigned index, const QColor &fgColor) {
+    if (index < items.size()) {
+        items[index].configure(items[index].selector->text(), backgroundColor, fgColor);
+    }
+}
+
+unsigned DataGrid::addItem(const QString &text, const QColor &fgColor) {
     unsigned index = items.size();
     items.resize(index + 1);
 
     CursorInfo& info = items.at(index);
-    info.configure(text, bgColor, fgColor);
+    info.configure(text, backgroundColor, fgColor);
     cursorsSelectorGroup->addButton(info.selector, index);
 
     connect(info.shape, &QPushButton::clicked, [this, index] () {

--- a/openhantek/src/widgets/datagrid.cpp
+++ b/openhantek/src/widgets/datagrid.cpp
@@ -1,0 +1,111 @@
+#include "datagrid.h"
+
+#include <QGridLayout>
+#include <QLabel>
+#include <QPushButton>
+#include <QButtonGroup>
+
+DataGrid::DataGrid(QWidget *parent) : QGroupBox(parent)
+{
+    cursorsLayout = new QGridLayout();
+    cursorsLayout->setSpacing(5);
+    cursorsSelectorGroup = new QButtonGroup();
+    cursorsSelectorGroup->setExclusive(true);
+
+    connect(cursorsSelectorGroup,
+            static_cast<void(QButtonGroup::*)(int)>(&QButtonGroup::buttonPressed), [this] (int index) {
+        emit itemSelected(index);
+    });
+
+    setLayout(cursorsLayout);
+    setFixedWidth(180);
+}
+
+DataGrid::CursorInfo::CursorInfo() {
+    selector = new QPushButton();
+    selector->setCheckable(true);
+    shape = new QPushButton();
+    deltaXLabel = new QLabel();
+    deltaXLabel->setAlignment(Qt::AlignRight);
+    deltaYLabel = new QLabel();
+    deltaYLabel->setAlignment(Qt::AlignRight);
+}
+
+void DataGrid::CursorInfo::configure(const QString &text, const QColor &bgColor, const QColor &fgColor) {
+    selector->setText(text);
+    selector->setStyleSheet(QString(R"(
+        QPushButton {
+            color: %2;
+            background-color: %1;
+            border: 1px solid %2;
+        }
+        QPushButton:checked {
+            color: %1;
+            background-color: %2;
+        }
+        QPushButton:disabled {
+            color: %3;
+            border: 1px dotted %2;
+        }
+    )").arg(bgColor.name(QColor::HexArgb))
+       .arg(fgColor.name(QColor::HexArgb))
+       .arg(fgColor.darker().name(QColor::HexArgb)));
+
+    shape->setStyleSheet(QString(R"(
+        QPushButton {
+            color: %2;
+            background-color: %1;
+            border: none
+        }
+    )").arg(bgColor.name(QColor::HexArgb))
+       .arg(fgColor.name(QColor::HexArgb)));
+
+    QPalette palette;
+    palette.setColor(QPalette::Background, bgColor);
+    palette.setColor(QPalette::WindowText, fgColor);
+    deltaXLabel->setPalette(palette);
+    deltaYLabel->setPalette(palette);   
+}
+
+unsigned DataGrid::addItem(const QString &text, const QColor &bgColor, const QColor &fgColor) {
+    unsigned index = items.size();
+    items.resize(index + 1);
+
+    CursorInfo& info = items.at(index);
+    info.configure(text, bgColor, fgColor);
+    cursorsSelectorGroup->addButton(info.selector, index);
+
+    connect(info.shape, &QPushButton::clicked, [this, index] () {
+        emit itemUpdated(index);
+    });
+
+    cursorsLayout->addWidget(info.selector, 3 * index, 0);
+    cursorsLayout->addWidget(info.shape, 3 * index, 1);
+    cursorsLayout->addWidget(info.deltaXLabel, 3 * index + 1, 0);
+    cursorsLayout->addWidget(info.deltaYLabel, 3 * index + 1, 1);
+    cursorsLayout->setRowMinimumHeight(3 * index + 2, 10);
+    cursorsLayout->setRowStretch(3 * index, 0);
+    cursorsLayout->setRowStretch(3 * index + 3, 1);
+
+    return index;
+}
+
+void DataGrid::updateInfo(unsigned index, bool visible, const QString &strShape, const QString &strX, const QString &strY) {
+    if (index >= items.size()) return;
+    CursorInfo &info = items.at(index);
+    info.selector->setEnabled(visible);
+    if (visible) {
+         info.shape->setText(strShape);
+         info.deltaXLabel->setText(strX);
+         info.deltaYLabel->setText(strY);
+    } else {
+        info.shape->setText(QString());
+        info.deltaXLabel->setText(QString());
+        info.deltaYLabel->setText(QString());
+    }
+}
+
+void DataGrid::selectItem(unsigned index) {
+    if (index >= items.size()) return;
+    items[index].selector->setChecked(true);
+}

--- a/openhantek/src/widgets/datagrid.h
+++ b/openhantek/src/widgets/datagrid.h
@@ -1,0 +1,44 @@
+#ifndef DATAGRID_H
+#define DATAGRID_H
+
+#include <QGroupBox>
+
+class QPushButton;
+class QButtonGroup;
+class QLabel;
+class QGridLayout;
+
+class DataGrid : public QGroupBox
+{
+    Q_OBJECT
+public:
+    explicit DataGrid(QWidget *parent = nullptr);
+
+    struct CursorInfo {
+        QPushButton *selector;  ///< The name of the channel
+        QPushButton *shape;     ///< The cursor shape
+        QLabel *deltaXLabel;    ///< The horizontal distance between cursors
+        QLabel *deltaYLabel;    ///< The vertical distance between cursors
+
+        CursorInfo();
+        void configure(const QString &text, const QColor &bgColor, const QColor &fgColor);
+    };
+
+    unsigned addItem(const QString &text, const QColor &bgColor, const QColor &fgColor);
+    void updateInfo(unsigned index, bool visible, const QString &strShape = QString(),
+                    const QString &strX = QString(), const QString &strY = QString());
+
+signals:
+    void itemSelected(unsigned index);
+    void itemUpdated(unsigned index);
+
+public slots:
+    void selectItem(unsigned index);
+
+private:
+    QButtonGroup *cursorsSelectorGroup;
+    QGridLayout *cursorsLayout;
+    std::vector<CursorInfo> items;
+};
+
+#endif // DATAGRID_H

--- a/openhantek/src/widgets/datagrid.h
+++ b/openhantek/src/widgets/datagrid.h
@@ -1,7 +1,9 @@
-#ifndef DATAGRID_H
-#define DATAGRID_H
+// SPDX-License-Identifier: GPL-2.0+
+
+#pragma once
 
 #include <QGroupBox>
+#include <QPalette>
 
 class QPushButton;
 class QButtonGroup;
@@ -15,6 +17,7 @@ public:
     explicit DataGrid(QWidget *parent = nullptr);
 
     struct CursorInfo {
+        QPalette palette;       ///< The widget's palette
         QPushButton *selector;  ///< The name of the channel
         QPushButton *shape;     ///< The cursor shape
         QLabel *deltaXLabel;    ///< The horizontal distance between cursors
@@ -24,7 +27,9 @@ public:
         void configure(const QString &text, const QColor &bgColor, const QColor &fgColor);
     };
 
-    unsigned addItem(const QString &text, const QColor &bgColor, const QColor &fgColor);
+    unsigned addItem(const QString &text, const QColor &fgColor);
+    void setBackgroundColor(const QColor &bgColor);
+    void configureItem(unsigned index, const QColor &fgColor);
     void updateInfo(unsigned index, bool visible, const QString &strShape = QString(),
                     const QString &strX = QString(), const QString &strY = QString());
 
@@ -36,9 +41,8 @@ public slots:
     void selectItem(unsigned index);
 
 private:
+    QColor backgroundColor;
     QButtonGroup *cursorsSelectorGroup;
     QGridLayout *cursorsLayout;
     std::vector<CursorInfo> items;
 };
-
-#endif // DATAGRID_H

--- a/openhantek/src/widgets/sispinbox.cpp
+++ b/openhantek/src/widgets/sispinbox.cpp
@@ -160,18 +160,19 @@ void SiSpinBox::setMode(const int mode) { this->mode = mode; }
 
 /// \brief Generic initializations.
 void SiSpinBox::init() {
-    this->setMinimum(1e-12);
-    this->setMaximum(1e12);
-    this->setValue(1.0);
-    this->setDecimals(DBL_MAX_10_EXP + DBL_DIG); // Disable automatic rounding
-    this->unit = unit;
-    this->steps << 1.0 << 2.0 << 5.0 << 10.0;
+    setMinimum(1e-12);
+    setMaximum(1e12);
+    setValue(1.0);
+    setDecimals(DBL_MAX_10_EXP + DBL_DIG); // Disable automatic rounding
+    setFocusPolicy(Qt::NoFocus);
+    steps << 1.0 << 2.0 << 5.0 << 10.0;
 
-    this->steppedTo = false;
-    this->stepId = 0;
-    this->mode = 0;
+    steppedTo = false;
+    stepId = 0;
+    mode = 0;
 
-    connect(this, static_cast<void (QDoubleSpinBox::*)(double)>(&QDoubleSpinBox::valueChanged), this, &SiSpinBox::resetSteppedTo);
+    connect(this, static_cast<void (QDoubleSpinBox::*)(double)>(&QDoubleSpinBox::valueChanged),
+            this, &SiSpinBox::resetSteppedTo);
 }
 
 /// \brief Resets the ::steppedTo flag after the value has been changed.


### PR DESCRIPTION
Cursor measurements are ready for review:
- Cursors are defined on a per-channel basis, markers replaced with dedicated cursor `#0`;
- Implemented cursor load and save;
- Switch between `OFF` and `#` cursor shapes;

TODO:
- Implement better graphics for a cursor, maybe dotted line with "marching ants" animation on the selected cursor;
- Attach annotations to cursors, highlight positions of measurement points;
- Separate controls for cursor __ON/OFF__ switch and cursor shape selector;
- Display cursors / enable edits in a zoomed view;
- Position of cursor info grid: right / left / hidden;
- Anything else?

![screenshot_2018-01-28_20-35-35](https://user-images.githubusercontent.com/11679699/35485291-7bb0f4f0-046e-11e8-96d3-eb1de09d1fab.png)

