### PR TITLE
Fix device selection dialog size.

### DIFF
--- a/openhantek/src/selectdevice/selectsupporteddevice.ui
+++ b/openhantek/src/selectdevice/selectsupporteddevice.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>381</width>
-    <height>266</height>
+    <width>550</width>
+    <height>400</height>
    </rect>
   </property>
   <property name="windowTitle">


### PR DESCRIPTION
When no device is found, a bit more text is shown,
so make space for that.