### PR TITLE
fix segfault #183, improve SW trigger stability

### DIFF
--- a/openhantek/src/docks/HorizontalDock.cpp
+++ b/openhantek/src/docks/HorizontalDock.cpp
@@ -164,9 +164,16 @@ void HorizontalDock::setSamplerateLimits(double minimum, double maximum) {
 }
 
 void HorizontalDock::setSamplerateSteps(int mode, QList<double> steps) {
-    QSignalBlocker blocker(samplerateSiSpinBox);
-    this->samplerateSiSpinBox->setMode(mode);
-    this->samplerateSiSpinBox->setSteps(steps);
+    // Assume that method is invoked for fixed samplerate devices only
+    QSignalBlocker samplerateBlocker(samplerateSiSpinBox);
+    samplerateSiSpinBox->setMode(mode);
+    samplerateSiSpinBox->setSteps(steps);
+    samplerateSiSpinBox->setMinimum(steps.first());
+    samplerateSiSpinBox->setMaximum(steps.last());
+    // Make reasonable adjustments to the timebase spinbox
+    QSignalBlocker timebaseBlocker(timebaseSiSpinBox);
+    timebaseSiSpinBox->setMinimum(pow(10, floor(log10(1.0 / steps.last()))));
+    timebaseSiSpinBox->setMaximum(pow(10, ceil(log10(8192.0 / (steps.first() * 10)))));
 }
 
 /// \brief Called when the frequencybase spinbox changes its value.

--- a/openhantek/src/post/ppresult.cpp
+++ b/openhantek/src/post/ppresult.cpp
@@ -19,6 +19,7 @@ unsigned int PPresult::sampleCount() const { return (unsigned)analyzedData[0].vo
 unsigned int PPresult::channelCount() const { return (unsigned)analyzedData.size(); }
 
 double DataChannel::computeAmplitude() const {
+    if (voltage.sample.empty()) return 0.0;
     double minimalVoltage, maximalVoltage;
     minimalVoltage = maximalVoltage = voltage.sample[0];
 

--- a/openhantek/src/settings.cpp
+++ b/openhantek/src/settings.cpp
@@ -106,7 +106,8 @@ void DsoSettings::load() {
     for (ChannelID channel = 0; channel < scope.voltage.size(); ++channel) {
         store->beginGroup(QString("vertical%1").arg(channel));
         if (store->contains("gainStepIndex")) scope.voltage[channel].gainStepIndex = store->value("gainStepIndex").toUInt();
-        if (store->contains("couplingOrMathIndex")) scope.voltage[channel].couplingOrMathIndex = store->value("couplingIndex").toUInt();
+        if (store->contains("couplingOrMathIndex")) scope.voltage[channel].couplingOrMathIndex =
+                store->value("couplingOrMathIndex").toUInt();
         if (store->contains("inverted")) scope.voltage[channel].inverted = store->value("inverted").toBool();
         if (store->contains("offset")) scope.voltage[channel].offset = store->value("offset").toDouble();
         if (store->contains("trigger")) scope.voltage[channel].trigger = store->value("trigger").toDouble();

--- a/openhantek/src/widgets/sispinbox.cpp
+++ b/openhantek/src/widgets/sispinbox.cpp
@@ -124,7 +124,8 @@ void SiSpinBox::stepBy(int steps) {
             if (stepsId < 0) stepsId += stepsCount;
             value = pow(stepsSpan, floor((double)this->stepId / stepsCount)) * this->steps[stepsId];
         } else {
-            value = this->minimum() * this->steps[stepId];
+            stepId = std::min(std::max(stepId, 0), stepsCount);
+            value = this->steps[stepId];
         }
         if (value <= this->minimum() || value >= this->maximum()) break;
     }


### PR DESCRIPTION
Bugfix (#183) - both issues got addressed. 

Bundle of enhancements:
- made timebase -> samplerate mapping less aggressive, at least half of data samples are now reserved for SW trigger algorithm
- limited 6022BE/BL timebase spinbox range to 10 ns (10e-9 * 48e6 = __0.48 S/div__) ... 10 ms (in fact, 4 ms/div is the longest timebase accepted by SW trigger)
- fixed minor issue: math channel mode is not loaded from settings and reset to default __CH1+CH2__
