### PR TITLE
Segfault on startup fix, #182 related

### DIFF
--- a/openhantek/src/hantekdso/modelregistry.cpp
+++ b/openhantek/src/hantekdso/modelregistry.cpp
@@ -2,9 +2,10 @@
 
 #include "modelregistry.h"
 
-ModelRegistry *ModelRegistry::instance = new ModelRegistry();
-
-ModelRegistry *ModelRegistry::get() { return instance; }
+ModelRegistry *ModelRegistry::get() {
+    static ModelRegistry inst;
+    return &inst;
+}
 
 void ModelRegistry::add(DSOModel *model) { supportedModels.push_back(model); }
 

--- a/openhantek/src/hantekdso/modelregistry.h
+++ b/openhantek/src/hantekdso/modelregistry.h
@@ -11,6 +11,5 @@ public:
     void add(DSOModel* model);
     const std::list<DSOModel*> models() const;
 private:
-    static ModelRegistry* instance;
     std::list<DSOModel*> supportedModels;
 };


### PR DESCRIPTION
Fixes a segfault on startup. The previous code assumed that ModelRegistry::instance would be initialized before being used by other static initializers.

However, static initialization order is undefined.
Plus, at least unter C++11 and according to 6.7[stmt.decl] p.4, this initialization of get():inst is thread-safe.

(this might be relevant to https://github.com/OpenHantek/openhantek/issues/182)