### PR TITLE
added OpenSUSE specific build dependency packages

### DIFF
--- a/docs/build.md
+++ b/docs/build.md
@@ -5,8 +5,11 @@ layout: default
 For debian (stretch and newer), Ubuntu 17.04+ and Mint 17+ and other deb based distributions install named requirements like this:
 > apt install g++ cmake qttools5-dev qttools5-dev-tools libfftw3-dev binutils-dev libusb-1.0-0-dev libqt5opengl5-dev mesa-common-dev libgl1-mesa-dev libgles2-mesa-dev
 
-For rpm based distributions (Fedora 21+, OpenSuse) use this command:
+For distributions using dnf package manager (Fedora 21+) use this command:
 > dnf install cmake gcc-c++ qt5-qtbase-gui qt5-qttools-devel qt5-qttranslations fftw-devel binutils-devel libusb-devel mesa-libGL-devel mesa-libGLES-devel
+
+For OpenSUSE and related distributions use this command
+zypper install cmake gcc-c++ qt5-qtbase-devel qt5-qttools-devel qt5-qttranslations  binutils-devel libusb-devel Mesa-libGL-devel Mesa-libGLESv2-devel fftw3-devel 
 
 After you've installed the requirements run the following commands inside the directory of this package:
 > mkdir build <br>


### PR DESCRIPTION
OpenSUSE uses rpm packages but it's not a RHEL derivative, their packages have different names so the current instructions are wrong for OpenSUSE users.

This change fixes the issue.

I've successfully built openhantek on OpenSUSE Tumbleweed and it works with a Hantek 6022BE.

I used the source from the tar.gz distributed on the openhantek "website", **OpenHantek-openhantek-0eff8d4.tar.gz**