### PR TITLE
Automatically generate AppImage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: cpp
-
-sudo: required
+compiler: gcc
+sudo: require
 dist: trusty
 
 env:
@@ -11,21 +11,13 @@ addons:
   apt:
     sources:
     - ubuntu-toolchain-r-test
-#    - llvm-toolchain-trusty-3.9
     packages: &native_deps
     - cmake
     - libusb-1.0-0-dev
     - libfftw3-dev
-#    - libqt5qml5
     - libgtest-dev
-#    - libqt5opengl5-dev
-#    - qtbase5-dev
-#    - qttools5-dev
-#    - qttools5-dev-tools
     - gcc-5
     - g++-5
-#    - doxygen
-#    - clang-3.6
 
 # We are testing
 # * linux with g++5 (and clang 3.6)
@@ -35,9 +27,6 @@ matrix:
     - compiler: gcc
       env: CMAKE_CXX_COMPILER=g++-5
       os: linux
-#    - compiler: clang
-#      env: CMAKE_CXX_COMPILER=clang++-3.6
-#      os: linux
     - compiler: clang
       env: CMAKE_CXX_COMPILER=/usr/bin/clang++
       os: osx
@@ -49,11 +38,27 @@ before_install:
 before_script:
     - mkdir build
     - cd build
-    - cmake -DCMAKE_CXX_COMPILER=$CMAKE_CXX_COMPILER -DCMAKE_PREFIX_PATH=$CMAKE_PREFIX_PATH ../
-
+    - cmake -DCMAKE_CXX_COMPILER=$CMAKE_CXX_COMPILER -DCMAKE_INSTALL_PREFIX=/usr -DCMAKE_BUILD_TYPE=Release ../
+ 
 script:
-    - make -j4
-
+    - make DESTDIR=appdir -j$(nproc) install ; find appdir/
+    - mkdir -p appdir/usr/share/applications/ ; cp ../openhantek.desktop appdir/usr/share/applications/ # FIXME, "make install" should do that
+    - mkdir -p appdir/usr/share/icons/hicolor/scalable/ ; cp ../openhantek/res/images/openhantek.svg appdir/usr/share/icons/hicolor/scalable/ # FIXME, "make install" should do that
+    - wget -c -nv "https://github.com/probonopd/linuxdeployqt/releases/download/continuous/linuxdeployqt-continuous-x86_64.AppImage"
+    - chmod a+x linuxdeployqt-continuous-x86_64.AppImage
+    - unset QTDIR; unset QT_PLUGIN_PATH ; unset LD_LIBRARY_PATH
+    - export VERSION=$(git rev-parse --short HEAD) # linuxdeployqt uses this for naming the file
+    - ./linuxdeployqt-continuous-x86_64.AppImage appdir/usr/share/applications/*.desktop -bundle-non-qt-libs
+    - # Workaround to increase compatibility with older systems; see https://github.com/darealshinji/AppImageKit-checkrt for details
+    - mkdir -p appdir/usr/optional/ ; wget -c https://github.com/darealshinji/AppImageKit-checkrt/releases/download/continuous/exec-x86_64.so -O ./appdir/usr/optional/exec.so
+    - rm -f appdir/AppRun ; cp ../AppRun appdir/ ; chmod +x appdir/AppRun
+    - mkdir -p appdir/usr/optional/libstdc++/ ; cp /usr/lib/x86_64-linux-gnu/libstdc++.so.6 ./appdir/usr/optional/libstdc++/
+    - ( cd appdir ; wget -c https://github.com/darealshinji/AppImageKit-checkrt/releases/download/continuous/AppRun-patched-x86_64 -O AppRun2 ; chmod a+x AppRun2)
+    - ./linuxdeployqt*.AppImage --appimage-extract
+    - export PATH=$(readlink -f ./squashfs-root/usr/bin):$PATH
+    - ./squashfs-root/usr/bin/appimagetool -g ./appdir/ "OpenHantek-$VERSION-x86_64.AppImage"
+    -  curl --upload-file OpenHantek-*-x86_64.AppImage https://transfer.sh/
+    
 before_deploy:
     - sudo make package
 

--- a/AppRun
+++ b/AppRun
@@ -1,0 +1,44 @@
+#!/bin/bash
+
+HERE="$(dirname "$(readlink -f "${0}")")"
+
+cat > /tmp/roothelper <<\EOoF
+#!/bin/bash
+cat > /etc/udev/rules.d/60-hantek.rules <<\EOF
+# Hantek DSO-2090
+SUBSYSTEM=="usb", ACTION=="add", ENV{DEVTYPE}=="usb_device", ATTRS{idVendor}=="04b5", ATTRS{idProduct}=="2090", TAG+="uaccess", TAG+="udev-acl"
+SUBSYSTEM=="usb", ACTION=="add", ENV{DEVTYPE}=="usb_device", ATTRS{idVendor}=="04b4", ATTRS{idProduct}=="2090", TAG+="uaccess", TAG+="udev-acl"
+SUBSYSTEM=="usb", ACTION=="add", ENV{DEVTYPE}=="usb_device", ATTRS{idVendor}=="04b4", ATTRS{idProduct}=="8613", TAG+="uaccess", TAG+="udev-acl"
+
+# Hantek DSO-2150
+SUBSYSTEM=="usb", ACTION=="add", ENV{DEVTYPE}=="usb_device", ATTRS{idVendor}=="04b5", ATTRS{idProduct}=="2150", TAG+="uaccess", TAG+="udev-acl"
+SUBSYSTEM=="usb", ACTION=="add", ENV{DEVTYPE}=="usb_device", ATTRS{idVendor}=="04b4", ATTRS{idProduct}=="2150", TAG+="uaccess", TAG+="udev-acl"
+
+# Hantek DSO-2250
+SUBSYSTEM=="usb", ACTION=="add", ENV{DEVTYPE}=="usb_device", ATTRS{idVendor}=="04b5", ATTRS{idProduct}=="2250", TAG+="uaccess", TAG+="udev-acl"
+SUBSYSTEM=="usb", ACTION=="add", ENV{DEVTYPE}=="usb_device", ATTRS{idVendor}=="04b4", ATTRS{idProduct}=="2250", TAG+="uaccess", TAG+="udev-acl"
+
+# Hantek DSO-5200
+SUBSYSTEM=="usb", ACTION=="add", ENV{DEVTYPE}=="usb_device", ATTRS{idVendor}=="04b5", ATTRS{idProduct}=="5200", TAG+="uaccess", TAG+="udev-acl"
+SUBSYSTEM=="usb", ACTION=="add", ENV{DEVTYPE}=="usb_device", ATTRS{idVendor}=="04b4", ATTRS{idProduct}=="5200", TAG+="uaccess", TAG+="udev-acl"
+
+# Hantek DSO-5200A
+SUBSYSTEM=="usb", ACTION=="add", ENV{DEVTYPE}=="usb_device", ATTRS{idVendor}=="04b5", ATTRS{idProduct}=="520a", TAG+="uaccess", TAG+="udev-acl"
+SUBSYSTEM=="usb", ACTION=="add", ENV{DEVTYPE}=="usb_device", ATTRS{idVendor}=="04b4", ATTRS{idProduct}=="520a", TAG+="uaccess", TAG+="udev-acl"
+
+# Hantek DSO-6022BE/BL
+SUBSYSTEM=="usb", ACTION=="add", ENV{DEVTYPE}=="usb_device", ATTRS{idVendor}=="04b5", ATTRS{idProduct}=="6022", TAG+="uaccess", TAG+="udev-acl"
+SUBSYSTEM=="usb", ACTION=="add", ENV{DEVTYPE}=="usb_device", ATTRS{idVendor}=="04b5", ATTRS{idProduct}=="602a", TAG+="uaccess", TAG+="udev-acl"
+SUBSYSTEM=="usb", ACTION=="add", ENV{DEVTYPE}=="usb_device", ATTRS{idVendor}=="04b4", ATTRS{idProduct}=="6022", TAG+="uaccess", TAG+="udev-acl"
+SUBSYSTEM=="usb", ACTION=="add", ENV{DEVTYPE}=="usb_device", ATTRS{idVendor}=="04b4", ATTRS{idProduct}=="602a", TAG+="uaccess", TAG+="udev-acl"
+EOF
+udevadm trigger
+EOoF
+chmod a+x /tmp/roothelper
+
+sudo true && sudo /tmp/roothelper
+sudo true || pkexec --disable-internal-agent /tmp/roothelper || true
+
+rm /tmp/roothelper
+
+exec "$HERE/AppRun2" "$@"

--- a/openhantek.desktop
+++ b/openhantek.desktop
@@ -1,0 +1,7 @@
+[Desktop Entry]
+Type=Application
+Comment=DSO software for Hantek (Voltcraft/Darkwire/Protek/Acetech) USB digital signal oscilloscopes
+Name=OpenHantek
+Exec=OpenHantek --useGLES
+Icon=openhantek
+Categories=Development;


### PR DESCRIPTION
This PR, when merged, will compile this application on [Travis CI](https://travis-ci.org/) upon each `git push`, and upload an [AppImage](http://appimage.org/) to your GitHub Releases page.

__Please note: Instead of uploading to transfer.sh, please change this to use the GitHub Releases mechanism you are already using for the other build products.__ If you also want to upload continuous builds, you can use something like https://github.com/probonopd/uploadtool.

Providing an [AppImage](http://appimage.org/) would have, among others, these advantages:
- Applications packaged as an AppImage can run on many distributions (including Ubuntu, Fedora, openSUSE, CentOS, elementaryOS, Linux Mint, and others)
- One app = one file = super simple for users: just download one AppImage file, [make it executable](http://discourse.appimage.org/t/how-to-make-an-appimage-executable/80), and run
- No unpacking or installation necessary
- No root needed
- No system libraries changed
- Works out of the box, no installation of runtimes needed
- Optional desktop integration with `appimaged`
- Optional binary delta updates, e.g., for continuous builds (only download the binary diff) using AppImageUpdate
- Can optionally GPG2-sign your AppImages (inside the file)
- Works on Live ISOs
- Can use the same AppImages when dual-booting multiple distributions
- Can be listed in the [AppImageHub](https://appimage.github.io/apps) central directory of available AppImages
- Can double as a self-extracting compressed archive with the `--appimage-extract` parameter

[Here is an overview](https://appimage.github.io/apps) of projects that are already distributing upstream-provided, official AppImages.

If you have questions, AppImage developers are on #AppImage on irc.freenode.net.