### PR TITLE
Use actual data returned from the cmdGetLimits.

### DIFF
--- a/openhantek/src/hantekdso/hantekdsocontrol.cpp
+++ b/openhantek/src/hantekdso/hantekdsocontrol.cpp
@@ -135,7 +135,7 @@ Dso::ErrorCode HantekDsoControl::retrieveChannelLevelData() {
         return Dso::ErrorCode::CONNECTION;
     }
 
-    memcpy(controlsettings.offsetLimit, controlsettings.cmdGetLimits.offsetLimitData(),
+    memcpy(controlsettings.offsetLimit, controlsettings.cmdGetLimits.data(),
            sizeof(OffsetsPerGainStep) * specification->channels);
 
     return Dso::ErrorCode::NONE;

--- a/openhantek/src/hantekprotocol/controlStructs.cpp
+++ b/openhantek/src/hantekprotocol/controlStructs.cpp
@@ -130,7 +130,7 @@ ControlAcquireHardData::ControlAcquireHardData() : ControlCommand(ControlCode::C
 }
 
 ControlGetLimits::ControlGetLimits(size_t channels)
-    : ControlCommand(ControlCode::CONTROL_VALUE, 1), offsetLimit(new OffsetsPerGainStep[channels]) {
+    : ControlCommand(ControlCode::CONTROL_VALUE, sizeof(OffsetsPerGainStep)*channels) {
     value = (uint8_t)ControlValue::VALUE_OFFSETLIMITS;
     data()[0] = 0x01;
 }

--- a/openhantek/src/hantekprotocol/controlStructs.h
+++ b/openhantek/src/hantekprotocol/controlStructs.h
@@ -129,8 +129,6 @@ struct ControlAcquireHardData : public ControlCommand {
 };
 
 struct ControlGetLimits : public ControlCommand {
-    std::unique_ptr<OffsetsPerGainStep[]> offsetLimit;
     ControlGetLimits(size_t channels);
-    inline uint8_t *offsetLimitData() { return (uint8_t *)offsetLimit.get(); }
 };
 }


### PR DESCRIPTION
Fixes #158