### PR TITLE
A little bit of refactoring for ChannelWidgets.

### DIFF
--- a/openhantek/src/widgets/dsowidget.cpp
+++ b/openhantek/src/widgets/dsowidget.cpp
@@ -418,7 +418,7 @@ ChannelWidgets::ChannelWidgets(Settings::Channel *channel, Settings::View *view,
     layout->addWidget(measurementAmplitudeLabel, 0, 4);
     layout->addWidget(measurementFrequencyLabel, 0, 5);
 
-    setMeasurementVisible();
+    updateMeasurementVisibility();
 
     if (!channel->isMathChannel()) {
         updateVoltageCoupling();
@@ -438,7 +438,7 @@ ChannelWidgets::ChannelWidgets(Settings::Channel *channel, Settings::View *view,
 }
 
 /// \brief Show/Hide a line of the measurement table.
-void ChannelWidgets::setMeasurementVisible() {
+void ChannelWidgets::updateMeasurementVisibility() {
     bool visible = channel->visible() || channel->spectrum()->visible();
 
     measurementNameLabel->setVisible(visible);
@@ -477,13 +477,13 @@ void ChannelWidgets::updateMathMode() {
 /// \param channel The channel whose used-state was changed.
 /// \param used The new used-state for the channel.
 void ChannelWidgets::updateVoltageUsed() {
-    setMeasurementVisible();
+    updateMeasurementVisibility();
     updateVoltageDetails();
 }
 
 /// \brief Update the label about the trigger settings
 void ChannelWidgets::updateVoltageDetails() {
-    setMeasurementVisible();
+    updateMeasurementVisibility();
 
     if (channel->visible()) {
         const double gain = channel->gain();
@@ -495,7 +495,7 @@ void ChannelWidgets::updateVoltageDetails() {
 
 /// \brief Update the label about the trigger settings
 void ChannelWidgets::updateSpectrumDetails() {
-    setMeasurementVisible();
+    updateMeasurementVisibility();
 
     if (channel->spectrum()->visible())
         measurementMagnitudeLabel->setText(

--- a/openhantek/src/widgets/dsowidget.h
+++ b/openhantek/src/widgets/dsowidget.h
@@ -25,8 +25,6 @@ class GlScopeWindow;
 class DsoControl;
 
 class ChannelWidgets : public QWidget {
-  Q_OBJECT
-  
   public:
     ChannelWidgets(Settings::Channel *channel, Settings::View *view, const Dso::ModelSpec *spec, QWidget *parent);
     ChannelWidgets(const ChannelWidgets &) = default;
@@ -39,7 +37,7 @@ class ChannelWidgets : public QWidget {
         delete measurementFrequencyLabel;
     }
 
-    void setMeasurementVisible();
+    void updateMeasurementVisibility();
     void updateVoltageCoupling();
     void updateMathMode();
     void updateSpectrumDetails();

--- a/openhantek/src/widgets/dsowidget.h
+++ b/openhantek/src/widgets/dsowidget.h
@@ -24,10 +24,11 @@ struct ModelSpec;
 class GlScopeWindow;
 class DsoControl;
 
-class ChannelWidgets : protected QWidget {
+class ChannelWidgets : public QWidget {
+  Q_OBJECT
+  
   public:
-    ChannelWidgets(Settings::Channel *channel, QGridLayout *measurementLayout, QWidget *parent = nullptr)
-        : QWidget(parent), measurementLayout(measurementLayout), channel(channel) {}
+    ChannelWidgets(Settings::Channel *channel, Settings::View *view, const Dso::ModelSpec *spec, QWidget *parent);
     ChannelWidgets(const ChannelWidgets &) = default;
     virtual ~ChannelWidgets() {
         delete measurementNameLabel;
@@ -37,10 +38,16 @@ class ChannelWidgets : protected QWidget {
         delete measurementAmplitudeLabel;
         delete measurementFrequencyLabel;
     }
-    inline QWidget *root() { return this; }
+
+    void setMeasurementVisible();
+    void updateVoltageCoupling();
+    void updateMathMode();
+    void updateSpectrumDetails();
+    void updateVoltageDetails();
+    void updateVoltageUsed();
 
   public:
-    QGridLayout *measurementLayout;                       ///< The table for the signal details
+    QGridLayout *layout = new QGridLayout(this);          ///< The table for the signal details
     QLabel *measurementNameLabel = new QLabel(this);      ///< The name of the channel
     QLabel *measurementMiscLabel = new QLabel(this);      ///< Coupling or math mode
     QLabel *measurementGainLabel = new QLabel(this);      ///< The gain for the voltage (V/div)
@@ -48,7 +55,9 @@ class ChannelWidgets : protected QWidget {
     QLabel *measurementAmplitudeLabel = new QLabel(this); ///< Amplitude of the signal (V)
     QLabel *measurementFrequencyLabel = new QLabel(this); ///< Frequency of the signal (Hz)
 
+    Settings::View *m_view;
     Settings::Channel *channel;
+    const Dso::ModelSpec *m_spec;
 };
 
 /// \brief The widget for the oszilloscope-screen
@@ -105,8 +114,6 @@ class DsoWidget : public QWidget {
   private:
     void applyColors();
     void createChannelWidgets(const QPalette &palette);
-    void setMeasurementVisible(ChannelWidgets *channelWidgets);
-    void updateSpectrumDetails(ChannelWidgets *channelWidgets);
     void updateTriggerDetails();
     void updateVoltageDetails(ChannelWidgets *channelWidgets);
 
@@ -116,13 +123,10 @@ class DsoWidget : public QWidget {
     void updateTriggerSource();
 
     // Spectrum
-    void updateSpectrumMagnitude(ChannelWidgets *channelWidgets);
-    void updateSpectrumUsed(ChannelWidgets *channelWidgets, bool used);
+    void updateSpectrumUsed(Settings::Channel *channel, bool used);
 
     // Vertical axis
-    void updateVoltageCoupling(ChannelWidgets *channelWidgets);
-    void updateMathMode(ChannelWidgets *channelWidgets);
-    void updateVoltageUsed(ChannelWidgets *channelWidgets, bool used);
+    void updateVoltageUsed(Settings::Channel *channel, bool used);
 
     /// Update the labels about the active marker measurements
     void updateMarkerDetails(int zoomviewIndex);


### PR DESCRIPTION
Make ChannelWidgets look more like a composite widget and layout
properly. Previously it was a widget which was never added to any layout.
Therefore it had default position (0,0) and size (100, 30) inside
it's parrent (DsoWidget). Whenever a trigger position/level slider was in
the left top corner, it was getting under invisible ChannelWidgets.
It this case it was impossible to get it out from there since all
the mouse events were directed to the ChannelWidgets.