### PR TITLE
Set cmake policy CMP0072 to choose OpenGL module

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,8 @@
 cmake_minimum_required(VERSION 3.5 FATAL_ERROR)
 project(OpenHantekProject)
 
+cmake_policy(SET CMP0072 NEW)
+
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
 # Default build type


### PR DESCRIPTION
If simultaneously available legacy GL library and GLVND library cmake should prefer the new one.
More info can be found by run 
cmake --help-policy CMP0072