### PR TITLE
A couple of low-level fixes.

### DIFF
--- a/openhantek/src/docks/HorizontalDock.cpp
+++ b/openhantek/src/docks/HorizontalDock.cpp
@@ -80,6 +80,8 @@ HorizontalDock::HorizontalDock(Settings::Scope *scope, DsoControl *dsocontrol, Q
     samplerateSiSpinBox = new SiSpinBox(Unit::SAMPLES, this);
     samplerateSiSpinBox->setRange(0, 0);
     samplerateSiSpinBox->setUnitPostfix("/s");
+    std::vector<double> samplerateSteps = {1.0, 2.0, 4.0, 10.0};
+    samplerateSiSpinBox->setSteps(samplerateSteps);
 
     fixedSamplerateBox = new QComboBox(this);
 

--- a/openhantek/src/hantekdso/devicesettings.h
+++ b/openhantek/src/hantekdso/devicesettings.h
@@ -204,7 +204,7 @@ class DeviceSettings : public QObject {
         if (!spec->supportsOffset || channel > spec->calibration.size()) return 0.001;
 
         const Dso::ModelSpec::GainStepCalibration &c = spec->calibration[channel][voltage[channel]->gainStepIndex()];
-        return 1 / (c.offsetEnd - c.offsetStart);
+        return 1.0 / (c.offsetEnd - c.offsetStart);
     }
 
     /// \brief Gets the maximum size of one packet transmitted via bulk transfer.

--- a/openhantek/src/hantekdso/dsocontrol.h
+++ b/openhantek/src/hantekdso/dsocontrol.h
@@ -108,7 +108,7 @@ class DsoControl : public DsoCommandQueue {
 
     /// \brief The resulting tuple of the computeBestSamplerate() function
     struct BestSamplerateResult {
-        unsigned downsampler = 0;
+        double downsampler = 0;
         double samplerate = 0.0;
         bool fastrate = false;
     };

--- a/openhantek/src/hantekdso/dsoloop.cpp
+++ b/openhantek/src/hantekdso/dsoloop.cpp
@@ -3,6 +3,7 @@
 #include "dsoloop.h"
 
 #include "dsocontrol.h"
+#include "viewconstants.h"
 #include "models/modelDSO6022.h"
 #include "usb/usbdevice.h"
 #include <QDebug>
@@ -380,7 +381,7 @@ void DsoLoop::convertRawDataToSamples(const std::vector<unsigned char> &rawData)
             for (unsigned pos = 0; pos < samples.size(); ++pos, bufferPosition += m_specification->channels) {
                 if (bufferPosition >= totalSampleCount) bufferPosition %= totalSampleCount;
                 const int16_t v = rawData[bufferPosition] - shiftDataBuf;
-                double samplePoint = (v / limit - harwareOffset) * gainStep - offsetCorrection;
+                double samplePoint = (v / limit - (harwareOffset+1)/2) * gainStep - offsetCorrection;
                 if (samplePoint < samples.minVoltage) samples.minVoltage = samplePoint;
                 if (samplePoint > samples.maxVoltage) samples.maxVoltage = samplePoint;
                 if (v < samples.minRaw) samples.minRaw = v;

--- a/openhantek/src/hantekdso/modelspecification.h
+++ b/openhantek/src/hantekdso/modelspecification.h
@@ -31,10 +31,10 @@ struct ControlSamplerateLimits {
     std::vector<RecordLength> recordLengths; ///< Available record lengths
 
     inline double minSamplerate(RecordLengthID id) const {
-        return base / maxDownsampler / recordLengths[id].recordLength;
+        return base / maxDownsampler / recordLengths[id].bufferDivider;
     }
     inline double samplerate(RecordLengthID id, unsigned downsampler) const {
-        return base / downsampler / recordLengths[id].recordLength;
+        return base / downsampler / recordLengths[id].bufferDivider;
     }
     inline double samplerate(RecordLengthID id, double recordTime) const {
         return recordLengths[id].bufferDivider / recordTime;
@@ -42,8 +42,8 @@ struct ControlSamplerateLimits {
 
     inline double maxSamplerate(RecordLengthID id) const { return max / recordLengths[id].bufferDivider; }
 
-    inline unsigned computeDownsampler(RecordLengthID id, double samplerate) const {
-        return unsigned(base / recordLengths[id].bufferDivider / samplerate);
+    inline double computeDownsampler(RecordLengthID id, double samplerate) const {
+        return base / recordLengths[id].bufferDivider / samplerate;
     }
 };
 

--- a/openhantek/src/hantekprotocol/controlStructs.cpp
+++ b/openhantek/src/hantekprotocol/controlStructs.cpp
@@ -130,7 +130,7 @@ ControlAcquireHardData::ControlAcquireHardData() : ControlCommand(HantekE::Contr
 }
 
 ControlGetLimits::ControlGetLimits(size_t channels)
-    : ControlCommand(HantekE::ControlCode::VALUE, 1), offsetLimit(new OffsetsPerGainStep[channels]) {
+    : ControlCommand(HantekE::ControlCode::VALUE, channels*sizeof(OffsetsPerGainStep)) {
     value = (uint8_t)ControlValue::VALUE_OFFSETLIMITS;
     data()[0] = 0x01;
 }

--- a/openhantek/src/hantekprotocol/controlStructs.h
+++ b/openhantek/src/hantekprotocol/controlStructs.h
@@ -139,7 +139,6 @@ struct ControlGetLimits : public ControlCommand {
     };
 #pragma pack(pop)
 
-    std::unique_ptr<OffsetsPerGainStep[]> offsetLimit;
     ControlGetLimits(size_t channels);
 };
 }

--- a/openhantek/src/post/graphgenerator.cpp
+++ b/openhantek/src/post/graphgenerator.cpp
@@ -53,14 +53,14 @@ void GraphGenerator::generateGraphsTYvoltage(PPresult *result) {
         // Set size directly to avoid reallocations
         target.resize(sampleCount);
 
-        // Data samples are in [0,1] (as long as the voltageLimits are set correctly).
+        // Data samples are in volts (as long as the voltageLimits are set correctly).
         // The offset needs to be applied now, as well as the gain.
         const float timeFactor =
-            float(channelData.voltage.interval * DIVS_TIME * 2 / m_deviceSettings->samplerate().timebase);
+            float(channelData.voltage.interval / m_deviceSettings->samplerate().timebase);
         const float offY = (float)channelData.channelSettings->voltage()->offset() * DIVS_VOLTAGE / 2;
         const float offX = -DIVS_TIME / 2;
         const int invert = channelData.channelSettings->inverted() ? -1.0 : 1.0;
-        const float gain = invert / channelData.channelSettings->gain();
+        const float gain = invert / channelData.channelSettings->gain() * DIVS_VOLTAGE;
 
 #pragma omp parallel for
         for (unsigned int position = 0; position < sampleCount; ++position) {

--- a/openhantek/src/scopeview/glscopegraph.cpp
+++ b/openhantek/src/scopeview/glscopegraph.cpp
@@ -83,20 +83,16 @@ void GlScopeGraph::ChannelDetail::updateGraph(const ChannelGraph &channelData) {
         dataBuffer->setData(tempBuffer);
     }
 
-    if (meshInit != channelData.size()) {
-        const unsigned s = (unsigned)channelData.size();
-        meshInit = s;
-        mesh->setVertexCount((int)s);
-        attr->setCount(s);
-    }
+    /// It looks like you need to set this each time you change the buffer contents.
+    const unsigned s = (unsigned)channelData.size();
+    mesh->setVertexCount((int)s);
+    attr->setCount(s);
 
     setEnabled(true);
 }
 
 GlScopeGraph::ChannelDetail::ChannelDetail(const ChannelGraph &channelData, QLayer *layer, const View *view,
                                            QEntity *parent) {
-    meshInit = (unsigned)channelData.size();
-
     if (layer) addComponent(layer);
 
     // Data buffer

--- a/openhantek/src/scopeview/glscopegraph.h
+++ b/openhantek/src/scopeview/glscopegraph.h
@@ -38,7 +38,6 @@ class GlScopeGraph : public Qt3DCore::QEntity {
         Qt3DExtras::QPhongAlphaMaterial *material = new Qt3DExtras::QPhongAlphaMaterial(this);
         Qt3DRender::QGeometryRenderer *mesh;
         Qt3DRender::QAttribute* attr;
-        unsigned meshInit = 0;
         ChannelID channelID;
         bool isSpectrum = false;
         QByteArray tempBuffer;

--- a/openhantek/src/settings/scopesettings.h
+++ b/openhantek/src/settings/scopesettings.h
@@ -71,7 +71,7 @@ class Scope : public QObject {
 
     DsoE::GraphFormat m_format = DsoE::GraphFormat::TY; ///< Graph drawing mode of the scope
     double m_frequencybase = 1e3;                     ///< Frequencybase in Hz/div
-    bool m_useHardwareGain = false;
+    bool m_useHardwareGain = true;
   signals:
     void formatChanged(const Scope *);
     void frequencybaseChanged(const Scope *);


### PR DESCRIPTION
This is probably my last commit on the openhantek2 branch.
I've got it to the stage when I can see the reference signal with
 - correct offset
 - correct period
 - correct amplitude
 - correct voltage measurement label at the bottom
 - it is possible to change the sample rate and the timebase is calculated correctly

Things which are still broken:
 - software gain control is broken (and turned off in this commit)
 - with the hardware gain control, the gain dropdown shows Vols per full
   scale instead of Volts per 1 div
 - hardware gain is not initialized when application is first started
   (need to select some other gain to initialize it)
 - hardware offset is not initialized when changing the gain level
   (need to shift the slider a bit to initialize it)
 - trigger offset and position are broken
 - axes lines are still randomly broken
 - only 10kS mode currently works
 - it is impossible to change the timebase directly using the spinner

Overall it looks like the codebase is in a pretty broken state.
At this point it feels easier to start over with something working and
incrementally apply refactoring on top of it while making sure that
none of the existing logic has changed.