### PR TITLE
Reset the device pointer before libusb_exit().

### DIFF
--- a/openhantek/src/main.cpp
+++ b/openhantek/src/main.cpp
@@ -205,7 +205,10 @@ int main(int argc, char *argv[]) {
     postProcessingThread.quit();
     postProcessingThread.wait(10000);
 
-    if (context && device != nullptr) { libusb_exit(context); }
+    if (context && device != nullptr) { 
+        device.reset(); // causes libusb_close(), which must be called before libusb_exit() 
+        libusb_exit(context); 
+    }
 
     return res;
 }


### PR DESCRIPTION
unique_ptr deletes target pointer when variable scope ends.
For variable "device" this is the whole main() function.
So Device is destroyed after main() is finished.
Device descructor is calling libusb_close. According to documentation
no libusb function is allowed to be called after libusb_exit().

Fixes #195