### PR TITLE
Fix the [no] downsampler border case for DSO 2250.

### DIFF
--- a/openhantek/src/hantekdso/hantekdsocontrol.cpp
+++ b/openhantek/src/hantekdso/hantekdsocontrol.cpp
@@ -531,11 +531,11 @@ unsigned HantekDsoControl::updateSamplerate(unsigned downsampler, bool fastRate)
         BulkSetSamplerate2250 *commandSetSamplerate2250 =
             modifyCommand<BulkSetSamplerate2250>(BulkCode::ESETTRIGGERORSAMPLERATE);
 
-        bool downsampling = downsampler >= 1;
+        bool downsampling = downsampler > 1;
         // Store downsampler state value
         commandSetSamplerate2250->setDownsampling(downsampling);
         // Store samplerate value
-        commandSetSamplerate2250->setSamplerate(downsampler > 1 ? 0x10001 - downsampler : 0);
+        commandSetSamplerate2250->setSamplerate(downsampling ? 0x10001 - downsampler : 0);
         // Set fast rate when used
         commandSetSamplerate2250->setFastRate(fastRate);
 


### PR DESCRIPTION
downsampler == 1 means divide by one => no downsampling, use the base clocks.

On 2250, frequency divider is a 16-bit up-counter. It outputs a pulse on
overflow when enabled and reloads the value which was passed in
the ESETTRIGGERORSAMPLERATE command.

If you enable downsampler with ESETTRIGGERORSAMPLERATE and:
 - write 0xffff as a counter (0x10001 - 2), it will divide by 2
 - write 0xfffe as a counter (0x10001 - 3), it will divide by 3
 ....
 - write 0x0001 as a counter (0x10001 - 0), it will divide by 65535
 - write 0x0000 as a counter (0x10001 - 1), it will divide by 65536

Fixes #81