### PR TITLE
Add cmath include for std::abs

### DIFF
--- a/openhantek/src/scopeview/glmoveresizesnap.cpp
+++ b/openhantek/src/scopeview/glmoveresizesnap.cpp
@@ -1,3 +1,4 @@
+#include <cmath>
 #include "glmoveresizesnap.h"
 #include <Qt3DInput/QMouseHandler>
 


### PR DESCRIPTION
a cmath include is needed for std::abs to resolve the overloading to float (errors on Clang)