### PR TITLE
fix Dark mode background introduced with MacOS 10.14 (mojave)

### DIFF
--- a/openhantek/src/widgets/sispinbox.cpp
+++ b/openhantek/src/widgets/sispinbox.cpp
@@ -41,6 +41,8 @@ SiSpinBox::SiSpinBox(Unit unit, QWidget *parent) : QDoubleSpinBox(parent) {
     this->init();
 
     this->setUnit(unit);
+
+    this->setBackground();
 }
 
 /// \brief Cleans up the main window.
@@ -177,3 +179,10 @@ void SiSpinBox::init() {
 
 /// \brief Resets the ::steppedTo flag after the value has been changed.
 void SiSpinBox::resetSteppedTo() { this->steppedTo = false; }
+
+// fix Dark mode background introduced with MacOS 10.24 (mojave)
+void SiSpinBox::setBackground() {
+    QPalette palette;
+    QColor background = palette.color(QPalette::Window);
+    this->setStyleSheet("background-color: " + background.name());
+}

--- a/openhantek/src/widgets/sispinbox.h
+++ b/openhantek/src/widgets/sispinbox.h
@@ -31,6 +31,7 @@ class SiSpinBox : public QDoubleSpinBox {
 
   private:
     void init();
+    void setBackground();
 
     Unit unit;           ///< The SI unit used for this spin box
     QString unitPostfix; ///< Shown after the unit


### PR DESCRIPTION
this fix set the correct background when you change the style.
without the patch and with Dark mode the text and background are
white; with this patch the text remain white but the background will
be set to dark.

thanks to @gmittone