### PR TITLE
fix for libusb dereference crash / update appveyor links

### DIFF
--- a/openhantek/src/usb/usbdevice.cpp
+++ b/openhantek/src/usb/usbdevice.cpp
@@ -99,7 +99,13 @@ bool USBDevice::connectDevice(QString &errorMessage) {
     return true;
 }
 
-USBDevice::~USBDevice() { disconnectFromDevice(); }
+USBDevice::~USBDevice() {
+	disconnectFromDevice();
+#if defined(_WIN32) || defined(_WIN64)
+	if (device != nullptr) libusb_unref_device(device);
+	device = nullptr;
+#endif
+}
 
 int USBDevice::claimInterface(const libusb_interface_descriptor *interfaceDescriptor, int endpointOut, int endPointIn) {
     int errorCode = libusb_claim_interface(this->handle, interfaceDescriptor->bInterfaceNumber);
@@ -135,7 +141,9 @@ void USBDevice::disconnectFromDevice() {
     }
     this->handle = nullptr;
 
+#if !defined(_WIN32) || !defined(_WIN64)
     libusb_unref_device(device);
+#endif
 
     emit deviceDisconnected();
 }

--- a/readme.md
+++ b/readme.md
@@ -1,4 +1,4 @@
-# OpenHantek [![Build Status](https://travis-ci.org/OpenHantek/openhantek.svg?branch=master)](https://travis-ci.org/OpenHantek/openhantek) [![Build status](https://ci.appveyor.com/api/projects/status/9w4rd5r04ufqafr4/branch/master?svg=true)](https://ci.appveyor.com/project/davidgraeff/openhantek/branch/master) [![Stability: Maintenance](https://masterminds.github.io/stability/maintenance.svg)](https://masterminds.github.io/stability/maintenance.html)
+# OpenHantek [![Build Status](https://travis-ci.org/OpenHantek/openhantek.svg?branch=master)](https://travis-ci.org/OpenHantek/openhantek) [![Build status](https://ci.appveyor.com/api/projects/status/github/openhantek/openhantek?branch=master&svg=true)](https://ci.appveyor.com/project/openhantek/openhantek/branch/master) [![Stability: Maintenance](https://masterminds.github.io/stability/maintenance.svg)](https://masterminds.github.io/stability/maintenance.html)
 
 OpenHantek is a free software for Hantek and compatible (Voltcraft/Darkwire/Protek/Acetech) USB digital signal oscilloscopes.
 


### PR DESCRIPTION
Original commit from 0x8BitStorm: https://github.com/thielj/openhantek/pull/2
He suggests that this a Windows only fix to prevent the libusb driver from crashing.
Tested succesful with a 6022BL on Windows 10 and winusb driver on both devices (VID_04B4&PID_602A / VID_04B5&PID_602A).

This pull request also includes a readme update for the appveyor links.