### PR TITLE
Possible fix for https://github.com/OpenHantek/openhantek/issues/265

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.5 FATAL_ERROR)
 project(OpenHantekProject)
 
-cmake_policy(SET CMP0072 NEW)
+set(OpenGL_GL_PREFERENCE GLVND)
 
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 


### PR DESCRIPTION
CMake policy CMP0072 was introduced in CMake version 3.11

Replace with equivalent version for older CMake versions