### PR TITLE
travis: fix release uploading

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,20 +1,14 @@
 language: cpp
-sudo: required
 dist: xenial
-
-env:
-  global:  
-   - GTEST_DIR=${TRAVIS_BUILD_DIR}/gtest
 
 addons:
   apt:
-    packages: &native_deps
+    packages:
+    - qtbase5-dev
+    - qttools5-dev-tools
+    - libqt5opengl5-dev
     - libusb-1.0-0-dev
     - libfftw3-dev
-    - libgtest-dev
-    - binutils-dev
-    - qtbase5-dev
-    - libqt5opengl5-dev
 
 matrix:
   include:
@@ -26,7 +20,7 @@ matrix:
       os: osx
   
 before_install:
-    - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew update; brew install fftw qt5; export CMAKE_PREFIX_PATH=$(brew --prefix qt5); fi
+    - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew update; brew install qt5 fftw binutils; export CMAKE_PREFIX_PATH=$(brew --prefix qt5); fi
     - if [[ "$TRAVIS_OS_NAME" != "osx" ]]; then pip install cmake --user; fi
 
 before_script:
@@ -41,10 +35,10 @@ before_deploy:
     - sudo make package
 
 deploy:
-  skip_cleanup: true
   provider: releases
-  api_key:
-    secure: XGiTAo3bIZXq1gWQQaodllxTX/Wg0Jwgs0Dxtwi688usIlyUheMmmda9Ot9hdrXTlxJJICgUE1RVwjYynE7c7uUKE9E82QlM/E05m+rAYXzCCzOdrkku2C7netAnFs8ZbNlfMn459QOAkPvbF0Wfx1h+pAYxpXbTFl0cwatBxIjVxc4BUpulbY2SJK413mm8nOwfHI/MpBaJwX2A1vaV4IevXWPVnLrypqA2g7B4N9NHnLB/kuBo6nKM9sjOLfvV7Lzmq/S2a9GeDF8JOO3OPjiQVLV+fwQbUn8l4Rfm6vzs1h4MYJ0E7QBV+laLbD3tHic9IcOHReinG64OTiA4uL8W75V556qGme4Eb6TId2SwnNtJPRU5zn5KIB3J6qXSrqA0XiPjm+lyxQF/LB4hIgMtr2r0t3a2+6zSOuu55D4W+IF4S7Q2ogRKyuu9Ku/QXPcmYRZQNkieXNUn7D6dANyQb6ml4uREZPlwHqLnbOi5RMBi5awiYY6NI8DLdcO4NXn+IsaWbJS50GQRGWJs/hB4PWXeuSAkjQ0kenPOf3ZcDhf73ynb/H6Z2gormgAFM91VC8yhvnjm+2zUMm+ChtYzX7xytCt34Itsrv7U+U1OdECMXRZkbbbvebbTeuo2jBqMdKEp4cDCvPEdrXlWwAFL//3sQvf2O23QEFkpTxY=
-  file: "packages/*"
+  api_key: $GITHUB_TOKEN
+  file_glob: true
+  file: packages/*
+  skip_cleanup: true
   on:
-    repo: OpenHantek/openhantek
+    tags: true


### PR DESCRIPTION
This commit fixes the travis deployment access denied issue.
Instead of the actual key it uses a variable that needs to be set manually.

Create a token with scope "repo" at:
https://github.com/settings/tokens

Copy the token code and add a environment variable at:
https://travis-ci.org/openhantek/openhantek/settings

GITHUB_TOKEN {token code}