### PR TITLE
set sample rate limits for horizontal dock on device init

### DIFF
--- a/openhantek/src/hantekdso/hantekdsocontrol.h
+++ b/openhantek/src/hantekdso/hantekdsocontrol.h
@@ -113,6 +113,9 @@ class HantekDsoControl : public QObject {
     }
     const ControlCommand *getCommand(Hantek::ControlCode code) const;
 
+    /// \brief Update the minimum and maximum supported samplerate.
+    void updateSamplerateLimits();
+
   private:
     bool isRollMode() const;
     bool isFastRate() const;
@@ -168,9 +171,6 @@ class HantekDsoControl : public QObject {
 
     /// \brief Restore the samplerate/timebase targets after divider updates.
     void restoreTargets();
-
-    /// \brief Update the minimum and maximum supported samplerate.
-    void updateSamplerateLimits();
 
   private:
     /// Pointers to bulk/control commands

--- a/openhantek/src/main.cpp
+++ b/openhantek/src/main.cpp
@@ -77,6 +77,7 @@ void applySettingsToDevice(HantekDsoControl *dsoControl, DsoSettingsScope *scope
     dsoControl->setPretriggerPosition(scope->trigger.position * scope->horizontal.timebase * DIVS_TIME);
     dsoControl->setTriggerSlope(scope->trigger.slope);
     dsoControl->setTriggerSource(scope->trigger.special, scope->trigger.source);
+    dsoControl->updateSamplerateLimits();
 }
 
 /// \brief Initialize resources and translations and show the main window.


### PR DESCRIPTION
Hello,

I have Hantek 6022BE. At first I was frustrated with behavior of sample rate spin box. It allowed to set values below 100k samples, although for 6022 it is hard coded that minimal supported sample rate is 100k. This modification updates sample rate limit in spin box to hard coded values.

Thanks.