### PR TITLE
override mesa openGL versions

### DIFF
--- a/openhantek/src/main.cpp
+++ b/openhantek/src/main.cpp
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: GPL-2.0+
 
+#include <QtGlobal>
 #include <QApplication>
 #include <QCommandLineParser>
 #include <QDebug>
@@ -92,18 +93,33 @@ int main(int argc, char *argv[]) {
 #endif
 
     bool useGles = false;
+    bool forceSl150 = false;
     {
         QCoreApplication parserApp(argc, argv);
         QCommandLineParser p;
         p.addHelpOption();
         p.addVersionOption();
+
         QCommandLineOption useGlesOption("useGLES", QCoreApplication::tr("Use OpenGL ES instead of OpenGL"));
         p.addOption(useGlesOption);
+
+        QCommandLineOption forceSl150Option("forceSL150", QCoreApplication::tr("Force OpenGL Shader Language version 1.50"));
+        p.addOption(forceSl150Option);
+
         p.process(parserApp);
         useGles = p.isSet(useGlesOption);
+        forceSl150 = p.isSet(forceSl150Option);
     }
 
     GlScope::fixOpenGLversion(useGles ? QSurfaceFormat::OpenGLES : QSurfaceFormat::OpenGL);
+
+    if (forceSl150) {
+      // set environment variables for Qt
+      qputenv("MESA_GL_VERSION_OVERRIDE", "3.2");
+      qputenv("MESA_GLSL_VERSION_OVERRIDE", "150");
+      qDebug() << "MESA_GL_VERSION_OVERRIDE =" << qgetenv("MESA_GL_VERSION_OVERRIDE").constData();
+      qDebug() << "MESA_GLSL_VERSION_OVERRIDE =" << qgetenv("MESA_GLSL_VERSION_OVERRIDE").constData();
+    }
 
     QApplication openHantekApplication(argc, argv);
 


### PR DESCRIPTION
add the `--forceSL150` flag to ignore the openGL Shader Language version reported by
```
glxinfo | grep -i "shading language"
```

this has the same effect as running
```
MESA_GL_VERSION_OVERRIDE=3.2 MESA_GLSL_VERSION_OVERRIDE=150 OpenHantek
```

http://www.mesa3d.org/envvars.html

>MESA_GL_VERSION_OVERRIDE
>changes the value returned by glGetString(GL_VERSION) and possibly the GL API type.
>Mesa may not really implement all the features of the given version. (for developers only)
>
>MESA_GLSL_VERSION_OVERRIDE
>changes the value returned by glGetString(GL_SHADING_LANGUAGE_VERSION). Valid values are integers, such as "130".
>Mesa will not really implement all the features of the given language version if it's higher than what's normally reported. (for developers only)

related issues are #221 and #236